### PR TITLE
TCPChat Version 1.3

### DIFF
--- a/CommonDefines/Classes.cs
+++ b/CommonDefines/Classes.cs
@@ -22,15 +22,16 @@ namespace CommonDefines
     }
     public class ServerMessageFormat
     {
-        public MessageTypes messageType { get; set; }
+        public MessageTypes MessageType { get; set; }
         public byte[] RSAExponent { get; set; }
         public byte[] RSAModulus { get; set; }
-        public ConsoleColor color { get; set; }
-        public string message { get; set; }
+        public ConsoleColor Color { get; set; }
+        public string Message { get; set; }
     }
     public class ConnectionMessageFormat
     {
-        public MessageTypes messageType { get; set; }
+        public MessageTypes MessageType { get; set; }
+        public string Username { get; set; }
         // Client's public key data.
         public byte[] RSAExponent { get; set; }
         public byte[] RSAModulus { get; set; }
@@ -40,20 +41,20 @@ namespace CommonDefines
     [Serializable]
     public class WelcomeMessageFormat
     {
-        public MessageTypes messageType { get; set; }
-        public string connectMessage { get; set; }
-        public string serverName { get; set; }
+        public MessageTypes MessageType { get; set; }
+        public string ConnectMessage { get; set; }
+        public string ServerName { get; set; }
         // The server's public key, that all users need to encrypt their message with.
-        public byte[] keyExponent { get; set; }
-        public byte[] keyModulus { get; set; }
+        public byte[] RSAExponent { get; set; }
+        public byte[] RSAModulus { get; set; }
         public string ServerVersion { get; set; }
     }
     [Serializable]
     // Inherits the userconfigformat as of now.
     public class MessageFormat : UserConfigFormat
     {
-        public MessageTypes messageType { get; set; }
-        public string message { get; set; }
+        public MessageTypes MessageType { get; set; }
+        public string Message { get; set; }
     }
     [Serializable]
     // The format that the user config should follow.
@@ -70,7 +71,7 @@ namespace CommonDefines
         // Variables to store the values that the config reader gets.
         public static string serverChosenName;
         public static string serverChosenWelcomeMessage;
-        public string serverName { get; set; }
-        public string serverWelcomeMessage { get; set; }
+        public string ServerName { get; set; }
+        public string ServerWelcomeMessage { get; set; }
     }
 }

--- a/CommonDefines/Classes.cs
+++ b/CommonDefines/Classes.cs
@@ -13,12 +13,21 @@ namespace CommonDefines
         ENCRYPTED = 4,
         DATAREQUEST = 5,
         DATAREPLY = 6,
+        MESSAGEREPLY = 7
     }
     public enum CommandDataTypes : int
     {
         CLIENTLIST = 0,
         PING = 1,
         CHANNELSWITCH = 2
+    }
+    public class MessageReplyFormat
+    {
+        public MessageTypes MessageType { get; set; }
+        public int ID { get; set; }
+        public string Username { get; set; }
+        public string Message { get; set; }
+        public ConsoleColor UsernameColor { get; set; }
     }
     // Keeps a list of clients and their RSA public key.
     public class ClientList
@@ -29,7 +38,7 @@ namespace CommonDefines
         public string Username { get; set; }
         public byte[] RSAExponent { get; set; }
         public byte[] RSAModulus { get; set; }
-
+        public ConsoleColor UsernameColor { get; set; }
     }
     public class ServerMessageFormat
     {
@@ -47,6 +56,7 @@ namespace CommonDefines
         public byte[] RSAExponent { get; set; }
         public byte[] RSAModulus { get; set; }
         public string ClientVersion { get; set; }
+        public ConsoleColor UserNameColor { get; set; }
     }
     public class WelcomeMessageFormat
     {
@@ -73,11 +83,10 @@ namespace CommonDefines
         public string Data { get; set; }
     }
     // Inherits the userconfigformat as of now.
-    public class MessageFormat : UserConfigFormat
+    public class MessageFormat
     {
         public MessageTypes MessageType { get; set; }
         public string Message { get; set; }
-        public int ID { get; set; }
     }
     // The format that the user config should follow.
     public class UserConfigFormat

--- a/CommonDefines/Classes.cs
+++ b/CommonDefines/Classes.cs
@@ -22,6 +22,7 @@ namespace CommonDefines
     // Keeps a list of clients and their RSA public key.
     public class ClientList
     {
+        public int ID { get; set; }
         public TcpClient TCPClient { get; set; }
         public string Username { get; set; }
         public byte[] RSAExponent { get; set; }
@@ -54,6 +55,7 @@ namespace CommonDefines
         public byte[] RSAExponent { get; set; }
         public byte[] RSAModulus { get; set; }
         public string ServerVersion { get; set; }
+        public int ClientID { get; set; }
     }
     public class DataRequestFormat
     {
@@ -72,6 +74,7 @@ namespace CommonDefines
     {
         public MessageTypes MessageType { get; set; }
         public string Message { get; set; }
+        public int ID { get; set; }
     }
     // The format that the user config should follow.
     public class UserConfigFormat

--- a/CommonDefines/Classes.cs
+++ b/CommonDefines/Classes.cs
@@ -45,7 +45,6 @@ namespace CommonDefines
         public byte[] RSAExponent { get; set; }
         public byte[] RSAModulus { get; set; }
         public string ClientVersion { get; set; }
-        public int ClientID { get; set; }
     }
     public class WelcomeMessageFormat
     {

--- a/CommonDefines/Classes.cs
+++ b/CommonDefines/Classes.cs
@@ -13,13 +13,25 @@ namespace CommonDefines
         ENCRYPTED = 4,
         DATAREQUEST = 5,
         DATAREPLY = 6,
-        MESSAGEREPLY = 7
+        MESSAGEREPLY = 7,
+        PRIVATEMESSAGE = 8
     }
     public enum CommandDataTypes : int
     {
         CLIENTLIST = 0,
         PING = 1,
-        CHANNELSWITCH = 2
+        CHANNELSWITCH = 2,
+        PRIVATEMESSSAGE = 3
+    }
+    public class PrivateMessageFormat
+    {
+        public MessageTypes MessageType { get; set; }
+        public byte[] RSAExponent { get; set; }
+        public byte[] RSAModulus { get; set; }
+        public ConsoleColor Color { get; set; }
+        public string Message { get; set; }
+        public string SenderUsername { get; set; }
+        public int SenderID { get; set; }
     }
     public class MessageReplyFormat
     {

--- a/CommonDefines/Classes.cs
+++ b/CommonDefines/Classes.cs
@@ -16,6 +16,7 @@ namespace CommonDefines
     public class ClientList
     {
         public TcpClient TCPClient { get; set; }
+        public string Username { get; set; }
         public byte[] RSAExponent { get; set; }
         public byte[] RSAModulus { get; set; }
 

--- a/CommonDefines/Classes.cs
+++ b/CommonDefines/Classes.cs
@@ -10,7 +10,13 @@ namespace CommonDefines
         CONNECTION = 1,
         WELCOME = 2,
         SERVER = 3,
-        ENCRYPTED = 4
+        ENCRYPTED = 4,
+        DATAREQUEST = 5,
+        DATAREPLY = 6,
+    }
+    public enum CommandDataTypes : int
+    {
+        CLIENTLIST = 0
     }
     // Keeps a list of clients and their RSA public key.
     public class ClientList
@@ -37,7 +43,6 @@ namespace CommonDefines
         public byte[] RSAExponent { get; set; }
         public byte[] RSAModulus { get; set; }
         public string ClientVersion { get; set; }
-
     }
     public class WelcomeMessageFormat
     {
@@ -48,6 +53,17 @@ namespace CommonDefines
         public byte[] RSAExponent { get; set; }
         public byte[] RSAModulus { get; set; }
         public string ServerVersion { get; set; }
+    }
+    public class DataRequestFormat
+    {
+        public MessageTypes MessageType { get; set; }
+        public CommandDataTypes DataType { get; set; }
+    }
+    public class DataReplyFormat
+    {
+        public MessageTypes MessageType { get; set; }
+        public CommandDataTypes DataType { get; set; }
+        public string Data { get; set; }
     }
     // Inherits the userconfigformat as of now.
     public class MessageFormat : UserConfigFormat

--- a/CommonDefines/Classes.cs
+++ b/CommonDefines/Classes.cs
@@ -20,6 +20,14 @@ namespace CommonDefines
         public byte[] RSAModulus { get; set; }
 
     }
+    public class ServerMessageFormat
+    {
+        public MessageTypes messageType { get; set; }
+        public byte[] RSAExponent { get; set; }
+        public byte[] RSAModulus { get; set; }
+        public ConsoleColor color { get; set; }
+        public string message { get; set; }
+    }
     public class ConnectionMessageFormat
     {
         public MessageTypes messageType { get; set; }

--- a/CommonDefines/Classes.cs
+++ b/CommonDefines/Classes.cs
@@ -87,7 +87,11 @@ namespace CommonDefines
         // Variables to store the values that the config reader gets.
         public static string serverChosenName;
         public static string serverChosenWelcomeMessage;
+        public static int serverChosenClientTime;
+
         public string ServerName { get; set; }
         public string ServerWelcomeMessage { get; set; }
+        // Milliseconds
+        public int ClientTimeBetweenMessages { get; set; }
     }
 }

--- a/CommonDefines/Classes.cs
+++ b/CommonDefines/Classes.cs
@@ -17,12 +17,14 @@ namespace CommonDefines
     public enum CommandDataTypes : int
     {
         CLIENTLIST = 0,
-        PING = 1
+        PING = 1,
+        CHANNELSWITCH = 2
     }
     // Keeps a list of clients and their RSA public key.
     public class ClientList
     {
         public int ID { get; set; }
+        public int ChannelID { get; set; }
         public TcpClient TCPClient { get; set; }
         public string Username { get; set; }
         public byte[] RSAExponent { get; set; }
@@ -56,6 +58,7 @@ namespace CommonDefines
         public byte[] RSAModulus { get; set; }
         public string ServerVersion { get; set; }
         public int ClientID { get; set; }
+        public int DefaultChannelID { get; set; }
     }
     public class DataRequestFormat
     {
@@ -91,10 +94,12 @@ namespace CommonDefines
         public static string serverChosenName;
         public static string serverChosenWelcomeMessage;
         public static int serverChosenClientTime;
+        public static int serverChosenDefaultChannelID;
 
         public string ServerName { get; set; }
         public string ServerWelcomeMessage { get; set; }
         // Milliseconds
         public int ClientTimeBetweenMessages { get; set; }
+        public int DefaultChannelID { get; set; }
     }
 }

--- a/CommonDefines/Classes.cs
+++ b/CommonDefines/Classes.cs
@@ -16,7 +16,8 @@ namespace CommonDefines
     }
     public enum CommandDataTypes : int
     {
-        CLIENTLIST = 0
+        CLIENTLIST = 0,
+        PING = 1
     }
     // Keeps a list of clients and their RSA public key.
     public class ClientList
@@ -58,6 +59,7 @@ namespace CommonDefines
     {
         public MessageTypes MessageType { get; set; }
         public CommandDataTypes DataType { get; set; }
+        public string Parameters { get; set; }
     }
     public class DataReplyFormat
     {

--- a/CommonDefines/Classes.cs
+++ b/CommonDefines/Classes.cs
@@ -45,6 +45,7 @@ namespace CommonDefines
         public byte[] RSAExponent { get; set; }
         public byte[] RSAModulus { get; set; }
         public string ClientVersion { get; set; }
+        public int ClientID { get; set; }
     }
     public class WelcomeMessageFormat
     {

--- a/CommonDefines/Classes.cs
+++ b/CommonDefines/Classes.cs
@@ -4,11 +4,13 @@ using System.Net.Sockets;
 namespace CommonDefines
 {
     // Types of messages that can be sent, will be deprecated soon.
-    public enum MessageTypes : byte
+    public enum MessageTypes : int
     {
         MESSAGE = 0,
         CONNECTION = 1,
-        WELCOME = 2
+        WELCOME = 2,
+        SERVER = 3,
+        ENCRYPTED = 4
     }
     // Keeps a list of clients and their RSA public key.
     public class ClientList

--- a/CommonDefines/Classes.cs
+++ b/CommonDefines/Classes.cs
@@ -116,11 +116,14 @@ namespace CommonDefines
         public static string serverChosenWelcomeMessage;
         public static int serverChosenClientTime;
         public static int serverChosenDefaultChannelID;
+        public static bool serverChosenVersionCheck;
 
         public string ServerName { get; set; }
         public string ServerWelcomeMessage { get; set; }
         // Milliseconds
         public int ClientTimeBetweenMessages { get; set; }
         public int DefaultChannelID { get; set; }
+        public bool EnableVersionCheck { get; set; }
+
     }
 }

--- a/CommonDefines/Classes.cs
+++ b/CommonDefines/Classes.cs
@@ -39,7 +39,6 @@ namespace CommonDefines
         public string ClientVersion { get; set; }
 
     }
-    [Serializable]
     public class WelcomeMessageFormat
     {
         public MessageTypes MessageType { get; set; }
@@ -50,14 +49,12 @@ namespace CommonDefines
         public byte[] RSAModulus { get; set; }
         public string ServerVersion { get; set; }
     }
-    [Serializable]
     // Inherits the userconfigformat as of now.
     public class MessageFormat : UserConfigFormat
     {
         public MessageTypes MessageType { get; set; }
         public string Message { get; set; }
     }
-    [Serializable]
     // The format that the user config should follow.
     public class UserConfigFormat
     {

--- a/CommonDefines/Commands.cs
+++ b/CommonDefines/Commands.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
 
 namespace CommonDefines
 {

--- a/CommonDefines/Commands.cs
+++ b/CommonDefines/Commands.cs
@@ -7,6 +7,8 @@ namespace CommonDefines
     {
         public string Option { get; set; }
         public Action Action { get; set; }
+        public string Help { get; set; }
+        public List<string> Alias = new();
     }
     public class Commands
     {

--- a/CommonDefines/Commands.cs
+++ b/CommonDefines/Commands.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace CommonDefines
 {
@@ -15,14 +16,26 @@ namespace CommonDefines
         // Keep a list of all commands.
         public static List<CommandFormat> commandList = new();
         // A variable to update when an argument is written as a command.
-        public static string CommandArgument;
+        public static List<string> CommandArguments = new();
 
         public static void GetCommandType(string command)
         {
+            CommandArguments.Clear();
             string commandOption = command.Split('/', ' ')[1];
-
             string argument = command[(command.IndexOf(commandOption) + commandOption.Length)..];
-            CommandArgument = argument.Replace(" ", "");
+
+            if (argument.Contains(" "))
+            {
+                CommandArguments = argument.Split(" ").ToList();
+
+                // Remove because it adds index 0 as empty.
+                CommandArguments.RemoveAt(0);
+            }
+            else
+            {
+                // If there are not multiple arguments, insert to index 0
+                CommandArguments.Insert(0, argument);
+            }
 
             bool foundCommand = false;
 

--- a/CommonDefines/Commands.cs
+++ b/CommonDefines/Commands.cs
@@ -28,7 +28,7 @@ namespace CommonDefines
 
             for (int i = 0; i < commandList.Count; i++)
             {
-                if (commandOption == commandList[i].Option)
+                if (commandOption == commandList[i].Option || commandList[i].Alias.Contains(commandOption))
                 {
                     commandList[i].Action();
                     foundCommand = true;

--- a/CommonDefines/Commands.cs
+++ b/CommonDefines/Commands.cs
@@ -39,5 +39,25 @@ namespace CommonDefines
                 Console.WriteLine("ERROR: UNKNOWN COMMAND");
             }
         }
+        public static void HelpCommandCommon()
+        {
+            Console.WriteLine("The available commands are:");
+            for (int i = 0; i < Commands.commandList.Count; i++)
+            {
+                Console.WriteLine("Command:");
+                Console.WriteLine(String.Format("/{0}", Commands.commandList[i].Option));
+                if (Commands.commandList[i].Alias.Count > 0)
+                {
+                    Console.WriteLine("Alias:");
+                }
+                for (int j = 0; j < Commands.commandList[i].Alias.Count; j++)
+                {
+                    Console.WriteLine(String.Format("/{0}", Commands.commandList[i].Alias[j]));
+                }
+                Console.WriteLine("Information:");
+                Console.WriteLine(String.Format("{0}", Commands.commandList[i].Help));
+                Console.WriteLine();
+            }
+        }
     }
 }

--- a/CommonDefines/Commands.cs
+++ b/CommonDefines/Commands.cs
@@ -21,7 +21,7 @@ namespace CommonDefines
         {
             string commandOption = command.Split('/', ' ')[1];
 
-            string argument = command.Substring(command.IndexOf(commandOption) + commandOption.Length);
+            string argument = command[(command.IndexOf(commandOption) + commandOption.Length)..];
             CommandArgument = argument.Replace(" ", "");
 
             bool foundCommand = false;

--- a/CommonDefines/Commands.cs
+++ b/CommonDefines/Commands.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace CommonDefines
+{
+    public class CommandFormat
+    {
+        public string Option { get; set; }
+        public Action Action { get; set; }
+    }
+    public class Commands
+    {
+        // Keep a list of all commands.
+        public static List<CommandFormat> commandList = new List<CommandFormat>();
+        // A variable to update when an argument is written as a command.
+        public static string CommandArgument;
+
+        public static void GetCommandType(string command)
+        {
+            string commandOption = command.Split('/', ' ')[1];
+
+            string argument = command.Substring(command.IndexOf(commandOption) + commandOption.Length);
+            CommandArgument = argument.Replace(" ", "");
+
+            bool foundCommand = false;
+
+            for (int i = 0; i < commandList.Count; i++)
+            {
+                if (commandOption == commandList[i].Option)
+                {
+                    commandList[i].Action();
+                    foundCommand = true;
+                }
+            }
+            if (!foundCommand)
+            {
+                Console.WriteLine("ERROR: UNKNOWN COMMAND");
+            }
+        }
+    }
+}

--- a/CommonDefines/Commands.cs
+++ b/CommonDefines/Commands.cs
@@ -11,7 +11,7 @@ namespace CommonDefines
     public class Commands
     {
         // Keep a list of all commands.
-        public static List<CommandFormat> commandList = new List<CommandFormat>();
+        public static List<CommandFormat> commandList = new ();
         // A variable to update when an argument is written as a command.
         public static string CommandArgument;
 

--- a/CommonDefines/Commands.cs
+++ b/CommonDefines/Commands.cs
@@ -11,7 +11,7 @@ namespace CommonDefines
     public class Commands
     {
         // Keep a list of all commands.
-        public static List<CommandFormat> commandList = new ();
+        public static List<CommandFormat> commandList = new();
         // A variable to update when an argument is written as a command.
         public static string CommandArgument;
 

--- a/CommonDefines/Common.cs
+++ b/CommonDefines/Common.cs
@@ -42,6 +42,7 @@ namespace CommonDefines
         }
         public static MessageTypes ReturnMessageType(byte[] data)
         {
+            // TODO Improve this system, may be causing irregular cryptography errors.
             string byteASCII = Encoding.ASCII.GetString(new byte[] { data[16] });
 
             // First step. Try parse to find out if character is an integer or not.

--- a/CommonDefines/Common.cs
+++ b/CommonDefines/Common.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using System.Text;
 
 namespace CommonDefines
 {
 
-    public class MessageSerialization
+    public class Common
     {
 
         public static string ReturnEndOfStream(string text)
@@ -39,7 +40,26 @@ namespace CommonDefines
             }
             return 0;
         }
+        public static MessageTypes ReturnMessageType(byte[] data)
+        {
+            string byteASCII = Encoding.ASCII.GetString(new byte[] { data[16] });
 
+            int outNum;
+            // First step. Try parse to find out if character is an integer or not.
+            bool parse = int.TryParse(byteASCII, out outNum);
+            if (!parse)
+            {
+                return MessageTypes.ENCRYPTED;
+            }
+
+            // Second step. Check if the parsed integer is actually part of enum.
+            if (!Enum.IsDefined(typeof(MessageTypes), outNum))
+            {
+                return MessageTypes.ENCRYPTED;
+            }
+            // TODO Find better way to define byte locations.
+            // Byte number 16 is the position of the byte that indicates messagetype in a json formatted message.
+            return (MessageTypes)outNum;
+        }
     }
-
 }

--- a/CommonDefines/Common.cs
+++ b/CommonDefines/Common.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text.Json;
 
 namespace CommonDefines
 {
@@ -8,7 +6,7 @@ namespace CommonDefines
     public class MessageSerialization
     {
 
-        public static string ReturnEndOfStreamString(string text)
+        public static string ReturnEndOfStream(string text)
         {
             int indexToRemove = FindEndOfStream(text.ToCharArray());
             if (indexToRemove != 0)

--- a/CommonDefines/Common.cs
+++ b/CommonDefines/Common.cs
@@ -44,9 +44,8 @@ namespace CommonDefines
         {
             string byteASCII = Encoding.ASCII.GetString(new byte[] { data[16] });
 
-            int outNum;
             // First step. Try parse to find out if character is an integer or not.
-            bool parse = int.TryParse(byteASCII, out outNum);
+            bool parse = int.TryParse(byteASCII, out int outNum);
             if (!parse)
             {
                 return MessageTypes.ENCRYPTED;

--- a/CommonDefines/CommonDefines.csproj
+++ b/CommonDefines/CommonDefines.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>

--- a/CommonDefines/Encryption.cs
+++ b/CommonDefines/Encryption.cs
@@ -155,7 +155,7 @@ namespace CommonDefines
 
         public static byte[] ExtractKeyFromMessage(byte[] data)
         {
-            List<byte> byteList = new ();
+            List<byte> byteList = new();
 
             for (int i = 0; i < data.Length; i++)
             {
@@ -169,7 +169,7 @@ namespace CommonDefines
         }
         public static byte[] ExtractIVFromBytes(byte[] data)
         {
-            List<byte> byteList = new ();
+            List<byte> byteList = new();
 
             for (int i = 0; i < data.Length; i++)
             {
@@ -183,7 +183,7 @@ namespace CommonDefines
         }
         public static byte[] ExtractKeyFromBytes(byte[] data)
         {
-            List<byte> byteList = new ();
+            List<byte> byteList = new();
 
             for (int i = 0; i < data.Length; i++)
             {
@@ -197,8 +197,8 @@ namespace CommonDefines
         }
         public static byte[] AppendKeyToMessage(byte[] data, byte[] IV, byte[] key, RSAParameters publicKey)
         {
-            List<byte> listKey = new ();
-            List<byte> listMain = new ();
+            List<byte> listKey = new();
+            List<byte> listMain = new();
 
             // Add the keys to a separate list
             listKey.AddRange(key);

--- a/CommonDefines/Encryption.cs
+++ b/CommonDefines/Encryption.cs
@@ -155,7 +155,7 @@ namespace CommonDefines
 
         public static byte[] ExtractKeyFromMessage(byte[] data)
         {
-            List<byte> byteList = new List<byte>();
+            List<byte> byteList = new ();
 
             for (int i = 0; i < data.Length; i++)
             {
@@ -169,7 +169,7 @@ namespace CommonDefines
         }
         public static byte[] ExtractIVFromBytes(byte[] data)
         {
-            List<byte> byteList = new List<byte>();
+            List<byte> byteList = new ();
 
             for (int i = 0; i < data.Length; i++)
             {
@@ -183,7 +183,7 @@ namespace CommonDefines
         }
         public static byte[] ExtractKeyFromBytes(byte[] data)
         {
-            List<byte> byteList = new List<byte>();
+            List<byte> byteList = new ();
 
             for (int i = 0; i < data.Length; i++)
             {
@@ -197,8 +197,8 @@ namespace CommonDefines
         }
         public static byte[] AppendKeyToMessage(byte[] data, byte[] IV, byte[] key, RSAParameters publicKey)
         {
-            List<byte> listKey = new List<byte>();
-            List<byte> listMain = new List<byte>();
+            List<byte> listKey = new ();
+            List<byte> listMain = new ();
 
             // Add the keys to a separate list
             listKey.AddRange(key);

--- a/CommonDefines/Encryption.cs
+++ b/CommonDefines/Encryption.cs
@@ -77,9 +77,11 @@ namespace CommonDefines
 
         public static RSAParameters RSAParamaterCombiner(byte[] modulus, byte[] exponent)
         {
-            RSAParameters result = new RSAParameters();
-            result.Modulus = modulus;
-            result.Exponent = exponent;
+            RSAParameters result = new RSAParameters
+            {
+                Modulus = modulus,
+                Exponent = exponent
+            };
 
             return result;
         }

--- a/CommonDefines/Encryption.cs
+++ b/CommonDefines/Encryption.cs
@@ -21,6 +21,12 @@ namespace CommonDefines
 
         public const int keyLength = 256;
 
+
+
+        // TODO Add other encryption libraries which are more tested.
+        // Or redo encryption system. It is hard for me to verify the security of the current system.
+
+
         public static string DecryptMessageData(byte[] dataMessage)
         {
             // Extract the 256 bytes that make up the AES Key and IV at the beginning of the message.

--- a/CommonDefines/Encryption.cs
+++ b/CommonDefines/Encryption.cs
@@ -48,8 +48,6 @@ namespace CommonDefines
 
             string message = System.Text.Encoding.ASCII.GetString(AESDecrypt);
 
-
-
             return message;
         }
         public static void GenerateRSAKeys()
@@ -89,7 +87,6 @@ namespace CommonDefines
 
         public static byte[] AESDecrypt(byte[] data, byte[] key, byte[] IV)
         {
-
             using (var aes = Aes.Create())
             {
                 aes.KeySize = 128;
@@ -114,7 +111,6 @@ namespace CommonDefines
         }
         public static byte[] AESEncrypt(byte[] data, byte[] key, byte[] IV)
         {
-
             using (var aes = Aes.Create())
             {
                 aes.KeySize = 128;
@@ -138,8 +134,6 @@ namespace CommonDefines
         }
         public static byte[] RSAEncrypt(byte[] data, RSAParameters publicKey)
         {
-
-
             RSACryptoServiceProvider csp = new RSACryptoServiceProvider(keySize);
 
             csp.ImportParameters(publicKey);
@@ -150,7 +144,6 @@ namespace CommonDefines
         }
         public static byte[] RSADecrypt(byte[] data, RSAParameters privateKey)
         {
-
             RSACryptoServiceProvider csp = new RSACryptoServiceProvider(keySize);
 
             csp.ImportParameters(privateKey);
@@ -163,7 +156,6 @@ namespace CommonDefines
         public static byte[] ExtractKeyFromMessage(byte[] data)
         {
             List<byte> byteList = new List<byte>();
-
 
             for (int i = 0; i < data.Length; i++)
             {
@@ -221,7 +213,6 @@ namespace CommonDefines
             byte[] finalBytes = listMain.ToArray();
 
             return finalBytes;
-
         }
     }
 }

--- a/CommonDefines/ExceptionData.cs
+++ b/CommonDefines/ExceptionData.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CommonDefines
+{
+    public class ExceptionData
+    {
+        public static int ExceptionIdentification(Exception exception)
+        {
+            string baseEsception = exception.GetBaseException().ToString();
+            string strID = baseEsception.Split('(', ')') [1];
+
+            int id;
+            bool parse = int.TryParse(strID, out id);
+
+            // If parsing to integer was not possible, return -1
+            if (!parse)
+            {
+                return -1;
+            }
+            return id;
+        }
+    }
+}

--- a/CommonDefines/ExceptionData.cs
+++ b/CommonDefines/ExceptionData.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace CommonDefines
 {
@@ -9,7 +7,7 @@ namespace CommonDefines
         public static int ExceptionIdentification(Exception exception)
         {
             string baseEsception = exception.GetBaseException().ToString();
-            string strID = baseEsception.Split('(', ')') [1];
+            string strID = baseEsception.Split('(', ')')[1];
 
             int id;
             bool parse = int.TryParse(strID, out id);

--- a/CommonDefines/Output.cs
+++ b/CommonDefines/Output.cs
@@ -12,7 +12,7 @@ namespace CommonDefines
         }
         public static void RecievedMessageFormat(List<MessageFormat> list)
         {
-            CommonDefines.ConsoleOutput.OutputMessage(list[0].Message, list[0].Username, list[0].UserNameColor);
+            CommonDefines.ConsoleOutput.OutputMessage(list[0].Message, list[0].Username, list[0].UserNameColor, list[0].ID);
         }
         public static void RecievedWelcomeMessageFormat(List<WelcomeMessageFormat> list)
         {
@@ -25,11 +25,11 @@ namespace CommonDefines
             Encryption.clientCopyOfServerPublicKey = key;
         }
         // This is the common output method for both server and client.
-        public static void OutputMessage(string message, string username, ConsoleColor color)
+        public static void OutputMessage(string message, string username, ConsoleColor color, int id)
         {
             Console.ForegroundColor = color;
 
-            string output = String.Format("{0}: {1}", username, message);
+            string output = String.Format("({0}) {1}: {2}", id, username, message);
 
             Console.WriteLine(output);
             Console.ResetColor();

--- a/CommonDefines/Output.cs
+++ b/CommonDefines/Output.cs
@@ -10,6 +10,10 @@ namespace CommonDefines
         {
             CommonDefines.ConsoleOutput.OutputServerMessage(list[0].Message, list[0].Color);
         }
+        public static void RecievedPrivateMessageFormat(List<PrivateMessageFormat> list)
+        {
+            CommonDefines.ConsoleOutput.OutputPrivateMessage(list[0].Message, list[0].Color, list[0].SenderUsername, list[0].SenderID);
+        }
         public static void RecievedMessageReplyFormat(List<MessageReplyFormat> list, int channelID)
         {
             // CLIENT CAN ONLY RECIEVE MESSAGEREPLYFORMAT AS OF 1.3.0
@@ -40,6 +44,15 @@ namespace CommonDefines
             Console.ForegroundColor = color;
 
             string output = String.Format("SERVER - {0}", message);
+
+            Console.WriteLine(output);
+            Console.ResetColor();
+        }
+        public static void OutputPrivateMessage(string message, ConsoleColor color, string senderUsername, int senderID)
+        {
+            Console.ForegroundColor = color;
+
+            string output = String.Format("PRIVATE - ({0}){1}:{2}", senderID, senderUsername, message);
 
             Console.WriteLine(output);
             Console.ResetColor();

--- a/CommonDefines/Output.cs
+++ b/CommonDefines/Output.cs
@@ -4,32 +4,28 @@ using System.Security.Cryptography;
 
 namespace CommonDefines
 {
-    public class OutputMessage
+    public class ConsoleOutput
     {
-        public static void ServerRecievedMessage(List<MessageFormat> list)
+        public static void RecievedServerMessageFormat(List<ServerMessageFormat> list)
         {
-            OutputMessage.OutputMessageColor(list[0].message, list[0].Username, list[0].UserNameColor);
+            CommonDefines.ConsoleOutput.OutputServerMessage(list[0].Message, list[0].Color);
         }
-        public static void ClientRecievedServerMessageFormat(List<ServerMessageFormat> list)
+        public static void RecievedMessageFormat(List<MessageFormat> list)
         {
-            OutputMessage.OutputServerMessage(list[0].message, list[0].color);
+            CommonDefines.ConsoleOutput.OutputMessage(list[0].Message, list[0].Username, list[0].UserNameColor);
         }
-        public static void ClientRecievedMessageFormat(List<MessageFormat> list)
-        {
-            OutputMessage.OutputMessageColor(list[0].message, list[0].Username, list[0].UserNameColor);
-        }
-        public static void ClientRecievedWelcomeMessageFormat(List<WelcomeMessageFormat> list)
+        public static void RecievedWelcomeMessageFormat(List<WelcomeMessageFormat> list)
         {
             // Output Info
-            Console.WriteLine(list[0].serverName);
-            Console.WriteLine(list[0].connectMessage);
+            Console.WriteLine(list[0].ServerName);
+            Console.WriteLine(list[0].ConnectMessage);
 
             // Encryption
-            RSAParameters key = Encryption.RSAParamaterCombiner(list[0].keyModulus, list[0].keyExponent);
+            RSAParameters key = Encryption.RSAParamaterCombiner(list[0].RSAModulus, list[0].RSAExponent);
             Encryption.clientCopyOfServerPublicKey = key;
         }
         // This is the common output method for both server and client.
-        public static void OutputMessageColor(string message, string username, ConsoleColor color)
+        public static void OutputMessage(string message, string username, ConsoleColor color)
         {
             Console.ForegroundColor = color;
 

--- a/CommonDefines/Output.cs
+++ b/CommonDefines/Output.cs
@@ -8,16 +8,18 @@ namespace CommonDefines
     {
         public static void ServerRecievedMessage(List<MessageFormat> list)
         {
-            OutputMessage.OutputMessageWithColor(list[0].message, list[0].Username, list[0].UserNameColor);
+            OutputMessage.OutputMessageColor(list[0].message, list[0].Username, list[0].UserNameColor);
         }
-
+        public static void ClientRecievedServerMessageFormat(List<ServerMessageFormat> list)
+        {
+            OutputMessage.OutputServerMessage(list[0].message, list[0].color);
+        }
         public static void ClientRecievedMessageFormat(List<MessageFormat> list)
         {
-            OutputMessage.OutputMessageWithColor(list[0].message, list[0].Username, list[0].UserNameColor);
+            OutputMessage.OutputMessageColor(list[0].message, list[0].Username, list[0].UserNameColor);
         }
-        public static void ClientRecievedConnectedMessageFormat(List<WelcomeMessageFormat> list)
+        public static void ClientRecievedWelcomeMessageFormat(List<WelcomeMessageFormat> list)
         {
-
             // Output Info
             Console.WriteLine(list[0].serverName);
             Console.WriteLine(list[0].connectMessage);
@@ -25,27 +27,25 @@ namespace CommonDefines
             // Encryption
             RSAParameters key = Encryption.RSAParamaterCombiner(list[0].keyModulus, list[0].keyExponent);
             Encryption.clientCopyOfServerPublicKey = key;
-
-
-        }
-        public static void OutputOnlyMessage(string message)
-        {
-
-            Console.WriteLine(message);
-            Console.ResetColor();
-
         }
         // This is the common output method for both server and client.
-        public static void OutputMessageWithColor(string message, string username, ConsoleColor color)
+        public static void OutputMessageColor(string message, string username, ConsoleColor color)
         {
-
             Console.ForegroundColor = color;
 
             string output = String.Format("{0}: {1}", username, message);
 
             Console.WriteLine(output);
             Console.ResetColor();
+        }
+        public static void OutputServerMessage(string message, ConsoleColor color)
+        {
+            Console.ForegroundColor = color;
 
+            string output = String.Format("SERVER - {0}", message);
+
+            Console.WriteLine(output);
+            Console.ResetColor();
         }
     }
 }

--- a/CommonDefines/Output.cs
+++ b/CommonDefines/Output.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Security.Cryptography;
 
 namespace CommonDefines

--- a/CommonDefines/Output.cs
+++ b/CommonDefines/Output.cs
@@ -10,12 +10,10 @@ namespace CommonDefines
         {
             CommonDefines.ConsoleOutput.OutputServerMessage(list[0].Message, list[0].Color);
         }
-        public static void RecievedMessageReplyFormat(List<MessageReplyFormat> list)
+        public static void RecievedMessageReplyFormat(List<MessageReplyFormat> list, int channelID)
         {
-            // ONLY CLIENT CAN RECIEVE MESSAGEREPLYFORMAT AS OF 1.3.0
-            // SERVER'S OUTPUT HAS BEEN MOVED.
-            // TODO Include user's current channel in output.
-            CommonDefines.ConsoleOutput.OutputMessage(list[0].Message, list[0].Username, list[0].UsernameColor, list[0].ID);
+            // CLIENT CAN ONLY RECIEVE MESSAGEREPLYFORMAT AS OF 1.3.0
+            CommonDefines.ConsoleOutput.OutputMessage(list[0].Message, list[0].Username, list[0].UsernameColor, list[0].ID, channelID);
         }
         public static void RecievedWelcomeMessageFormat(List<WelcomeMessageFormat> list)
         {
@@ -28,11 +26,11 @@ namespace CommonDefines
             Encryption.clientCopyOfServerPublicKey = key;
         }
         // This is the common output method for both server and client.
-        public static void OutputMessage(string message, string username, ConsoleColor color, int id)
+        public static void OutputMessage(string message, string username, ConsoleColor color, int id, int channelID)
         {
             Console.ForegroundColor = color;
 
-            string output = String.Format("({0}) {1}: {2}", id, username, message);
+            string output = String.Format("{0} - ({1}){2}: {3}", channelID, id, username, message);
 
             Console.WriteLine(output);
             Console.ResetColor();

--- a/CommonDefines/Output.cs
+++ b/CommonDefines/Output.cs
@@ -12,6 +12,7 @@ namespace CommonDefines
         }
         public static void RecievedMessageFormat(List<MessageFormat> list)
         {
+            // TODO Include user's current channel in output.
             CommonDefines.ConsoleOutput.OutputMessage(list[0].Message, list[0].Username, list[0].UserNameColor, list[0].ID);
         }
         public static void RecievedWelcomeMessageFormat(List<WelcomeMessageFormat> list)

--- a/CommonDefines/Output.cs
+++ b/CommonDefines/Output.cs
@@ -10,10 +10,12 @@ namespace CommonDefines
         {
             CommonDefines.ConsoleOutput.OutputServerMessage(list[0].Message, list[0].Color);
         }
-        public static void RecievedMessageFormat(List<MessageFormat> list)
+        public static void RecievedMessageReplyFormat(List<MessageReplyFormat> list)
         {
+            // ONLY CLIENT CAN RECIEVE MESSAGEREPLYFORMAT AS OF 1.3.0
+            // SERVER'S OUTPUT HAS BEEN MOVED.
             // TODO Include user's current channel in output.
-            CommonDefines.ConsoleOutput.OutputMessage(list[0].Message, list[0].Username, list[0].UserNameColor, list[0].ID);
+            CommonDefines.ConsoleOutput.OutputMessage(list[0].Message, list[0].Username, list[0].UsernameColor, list[0].ID);
         }
         public static void RecievedWelcomeMessageFormat(List<WelcomeMessageFormat> list)
         {

--- a/CommonDefines/Serialization.cs
+++ b/CommonDefines/Serialization.cs
@@ -8,6 +8,18 @@ namespace CommonDefines
 {
     public class Serialization
     {
+        public static List<DataReplyFormat> DeserializeDataReplyFormat(string text)
+        {
+            List<DataReplyFormat> messageList = JsonSerializer.Deserialize<List<DataReplyFormat>>(text);
+
+            return messageList;
+        }
+        public static List<DataRequestFormat> DeserializeDataRequestFormat(string text)
+        {
+            List<DataRequestFormat> messageList = JsonSerializer.Deserialize<List<DataRequestFormat>>(text);
+
+            return messageList;
+        }
         public static List<ServerMessageFormat> DeserializeServerMessageFormat(string text)
         {
             List<ServerMessageFormat> messageList = JsonSerializer.Deserialize<List<ServerMessageFormat>>(text);

--- a/CommonDefines/Serialization.cs
+++ b/CommonDefines/Serialization.cs
@@ -38,6 +38,12 @@ namespace CommonDefines
 
             return messageList;
         }
+        public static List<MessageReplyFormat> DeserializeMessageReplyFormat(string text)
+        {
+            List<MessageReplyFormat> messageList = JsonSerializer.Deserialize<List<MessageReplyFormat>>(text);
+
+            return messageList;
+        }
         public static List<WelcomeMessageFormat> DeserializeWelcomeMessageFormat(string text)
         {
             List<WelcomeMessageFormat> messageList = JsonSerializer.Deserialize<List<WelcomeMessageFormat>>(text);

--- a/CommonDefines/Serialization.cs
+++ b/CommonDefines/Serialization.cs
@@ -51,7 +51,8 @@ namespace CommonDefines
             if (indent)
             {
                 json = JsonSerializer.Serialize(list, new JsonSerializerOptions { WriteIndented = true });
-            } else
+            }
+            else
             {
                 json = JsonSerializer.Serialize(list);
             }

--- a/CommonDefines/Serialization.cs
+++ b/CommonDefines/Serialization.cs
@@ -45,9 +45,16 @@ namespace CommonDefines
             return messageList;
         }
 
-        public static string Serialize<T>(List<T> list)
+        public static string Serialize<T>(List<T> list, bool indent)
         {
-            string json = JsonSerializer.Serialize(list);
+            string json;
+            if (indent)
+            {
+                json = JsonSerializer.Serialize(list, new JsonSerializerOptions { WriteIndented = true });
+            } else
+            {
+                json = JsonSerializer.Serialize(list);
+            }
 
             return json;
         }

--- a/CommonDefines/Serialization.cs
+++ b/CommonDefines/Serialization.cs
@@ -8,6 +8,12 @@ namespace CommonDefines
 {
     public class Serialization
     {
+        public static List<PrivateMessageFormat> DeserializePrivateMessageFormat(string text)
+        {
+            List<PrivateMessageFormat> messageList = JsonSerializer.Deserialize<List<PrivateMessageFormat>>(text);
+
+            return messageList;
+        }
         public static List<DataReplyFormat> DeserializeDataReplyFormat(string text)
         {
             List<DataReplyFormat> messageList = JsonSerializer.Deserialize<List<DataReplyFormat>>(text);

--- a/CommonDefines/Serialization.cs
+++ b/CommonDefines/Serialization.cs
@@ -8,6 +8,14 @@ namespace CommonDefines
 {
     public class Serialization
     {
+        public static List<ServerMessageFormat> DeserializeServerMessageFormat(string text)
+        {
+            List<ServerMessageFormat> messageList = new List<ServerMessageFormat>();
+
+            messageList = JsonSerializer.Deserialize<List<ServerMessageFormat>>(text);
+
+            return messageList;
+        }
         public static List<ConnectionMessageFormat> DeserializeConnectionMessageFormat(string text)
         {
             List<ConnectionMessageFormat> messageList = new List<ConnectionMessageFormat>();

--- a/CommonDefines/Serialization.cs
+++ b/CommonDefines/Serialization.cs
@@ -10,33 +10,25 @@ namespace CommonDefines
     {
         public static List<ServerMessageFormat> DeserializeServerMessageFormat(string text)
         {
-            List<ServerMessageFormat> messageList = new List<ServerMessageFormat>();
-
-            messageList = JsonSerializer.Deserialize<List<ServerMessageFormat>>(text);
+            List<ServerMessageFormat> messageList = JsonSerializer.Deserialize<List<ServerMessageFormat>>(text);
 
             return messageList;
         }
         public static List<ConnectionMessageFormat> DeserializeConnectionMessageFormat(string text)
         {
-            List<ConnectionMessageFormat> messageList = new List<ConnectionMessageFormat>();
-
-            messageList = JsonSerializer.Deserialize<List<ConnectionMessageFormat>>(text);
+            List<ConnectionMessageFormat> messageList = JsonSerializer.Deserialize<List<ConnectionMessageFormat>>(text);
 
             return messageList;
         }
         public static List<MessageFormat> DeserializeMessageFormat(string text)
         {
-            List<MessageFormat> messageList = new List<MessageFormat>();
-
-            messageList = JsonSerializer.Deserialize<List<MessageFormat>>(text);
+            List<MessageFormat> messageList = JsonSerializer.Deserialize<List<MessageFormat>>(text);
 
             return messageList;
         }
         public static List<WelcomeMessageFormat> DeserializeWelcomeMessageFormat(string text)
         {
-            List<WelcomeMessageFormat> messageList = new List<WelcomeMessageFormat>();
-
-            messageList = JsonSerializer.Deserialize<List<WelcomeMessageFormat>>(text);
+            List<WelcomeMessageFormat> messageList = JsonSerializer.Deserialize<List<WelcomeMessageFormat>>(text);
 
             return messageList;
         }

--- a/TCPChat-Client/ClientRecievedTypes.cs
+++ b/TCPChat-Client/ClientRecievedTypes.cs
@@ -45,6 +45,10 @@ namespace TCPChat_Client
                     List<DataReplyFormat> dataFormatList = Serialization.DeserializeDataReplyFormat(messageFormatted);
                     CommandHandler.RecievedDataReply(dataFormatList);
                     break;
+                case MessageTypes.PRIVATEMESSAGE:
+                    List<PrivateMessageFormat> privateMessagFormatList = Serialization.DeserializePrivateMessageFormat(messageFormatted);
+                    ConsoleOutput.RecievedPrivateMessageFormat(privateMessagFormatList);
+                    break;
             }
         }
     }

--- a/TCPChat-Client/ClientRecievedTypes.cs
+++ b/TCPChat-Client/ClientRecievedTypes.cs
@@ -33,9 +33,9 @@ namespace TCPChat_Client
 
             switch (Common.ReturnMessageType(messageBytes))
             {
-                case MessageTypes.MESSAGE:
-                    List<MessageFormat> messageFormatList = Serialization.DeserializeMessageFormat(messageFormatted);
-                    ConsoleOutput.RecievedMessageFormat(messageFormatList);
+                case MessageTypes.MESSAGEREPLY:
+                    List<MessageReplyFormat> messageFormatList = Serialization.DeserializeMessageReplyFormat(messageFormatted);
+                    ConsoleOutput.RecievedMessageReplyFormat(messageFormatList);
                     break;
                 case MessageTypes.SERVER:
                     List<ServerMessageFormat> serverFormatList = Serialization.DeserializeServerMessageFormat(messageFormatted);

--- a/TCPChat-Client/ClientRecievedTypes.cs
+++ b/TCPChat-Client/ClientRecievedTypes.cs
@@ -1,0 +1,46 @@
+﻿using CommonDefines;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TCPChat_Client
+{
+    public class ClientRecievedTypes
+    {
+        public static void ClientRecievedWelcomeMessage(byte[] data, Int32 bytes)
+        {
+            string responseData = Encoding.ASCII.GetString(data, 0, bytes);
+            string text = Common.ReturnEndOfStream(responseData);
+
+            List<WelcomeMessageFormat> connectList = Serialization.DeserializeWelcomeMessageFormat(text);
+
+            ConsoleOutput.RecievedWelcomeMessageFormat(connectList);
+        }
+        public static void ClientRecievedEncryptedMessage(byte[] data)
+        {
+            string message = Encryption.DecryptMessageData(data);
+
+
+            string messageFormatted = Common.ReturnEndOfStream(message);
+
+            // I have to return it to bytes for some reason, otherwise i get an incorrect character on byte pos 16.
+            byte[] messageBytes = Encoding.ASCII.GetBytes(messageFormatted);
+
+            switch (Common.ReturnMessageType(messageBytes))
+            {
+                case MessageTypes.MESSAGE:
+                    List<MessageFormat> messageFormatList = Serialization.DeserializeMessageFormat(messageFormatted);
+                    ConsoleOutput.RecievedMessageFormat(messageFormatList);
+                    break;
+                case MessageTypes.SERVER:
+                    List<ServerMessageFormat> serverFormatList = Serialization.DeserializeServerMessageFormat(messageFormatted);
+                    ConsoleOutput.RecievedServerMessageFormat(serverFormatList);
+                    break;
+                case MessageTypes.DATAREPLY:
+                    List<DataReplyFormat> dataFormatList = Serialization.DeserializeDataReplyFormat(messageFormatted);
+                    CommandHandler.RecievedDataReply(dataFormatList);
+                    break;
+            }
+        }
+    }
+}

--- a/TCPChat-Client/ClientRecievedTypes.cs
+++ b/TCPChat-Client/ClientRecievedTypes.cs
@@ -8,6 +8,7 @@ namespace TCPChat_Client
     public class ClientRecievedTypes
     {
         public static int ClientAssignedID;
+        public static int CurrentChannelID;
         public static void ClientRecievedWelcomeMessage(byte[] data, Int32 bytes)
         {
             string responseData = Encoding.ASCII.GetString(data, 0, bytes);
@@ -16,6 +17,7 @@ namespace TCPChat_Client
             List<WelcomeMessageFormat> connectList = Serialization.DeserializeWelcomeMessageFormat(text);
 
             ClientAssignedID = connectList[0].ClientID;
+            CurrentChannelID = connectList[0].DefaultChannelID;
 
             ConsoleOutput.RecievedWelcomeMessageFormat(connectList);
         }

--- a/TCPChat-Client/ClientRecievedTypes.cs
+++ b/TCPChat-Client/ClientRecievedTypes.cs
@@ -35,7 +35,7 @@ namespace TCPChat_Client
             {
                 case MessageTypes.MESSAGEREPLY:
                     List<MessageReplyFormat> messageFormatList = Serialization.DeserializeMessageReplyFormat(messageFormatted);
-                    ConsoleOutput.RecievedMessageReplyFormat(messageFormatList);
+                    ConsoleOutput.RecievedMessageReplyFormat(messageFormatList, CurrentChannelID);
                     break;
                 case MessageTypes.SERVER:
                     List<ServerMessageFormat> serverFormatList = Serialization.DeserializeServerMessageFormat(messageFormatted);

--- a/TCPChat-Client/ClientRecievedTypes.cs
+++ b/TCPChat-Client/ClientRecievedTypes.cs
@@ -7,12 +7,15 @@ namespace TCPChat_Client
 {
     public class ClientRecievedTypes
     {
+        public static int ClientAssignedID;
         public static void ClientRecievedWelcomeMessage(byte[] data, Int32 bytes)
         {
             string responseData = Encoding.ASCII.GetString(data, 0, bytes);
             string text = Common.ReturnEndOfStream(responseData);
 
             List<WelcomeMessageFormat> connectList = Serialization.DeserializeWelcomeMessageFormat(text);
+
+            ClientAssignedID = connectList[0].ClientID;
 
             ConsoleOutput.RecievedWelcomeMessageFormat(connectList);
         }

--- a/TCPChat-Client/CommandActions.cs
+++ b/TCPChat-Client/CommandActions.cs
@@ -71,23 +71,7 @@ namespace TCPChat_Client
     {
         public static void Execute()
         {
-            Console.WriteLine("The available commands are:");
-            for (int i = 0; i < Commands.commandList.Count; i++)
-            {
-                Console.WriteLine("Command:");
-                Console.WriteLine(String.Format("/{0}", Commands.commandList[i].Option));
-                if (Commands.commandList[i].Alias.Count > 0)
-                {
-                    Console.WriteLine("Alias:");
-                }
-                for (int j = 0; j < Commands.commandList[i].Alias.Count; j++)
-                {
-                    Console.WriteLine(String.Format("/{0}", Commands.commandList[i].Alias[j]));
-                }
-                Console.WriteLine("Information:");
-                Console.WriteLine(String.Format("{0}", Commands.commandList[i].Help));
-                Console.WriteLine();
-            }
+            Commands.HelpCommandCommon();
         }
     }
     class ExitAction

--- a/TCPChat-Client/CommandActions.cs
+++ b/TCPChat-Client/CommandActions.cs
@@ -20,7 +20,7 @@ namespace TCPChat_Client
             {
                 Option = "client",
                 Action = ClientDataAction.Execute,
-                Alias = {  },
+                Alias = { },
                 Help = "WIP Not in use."
             });
             Commands.commandList.Add(new CommandFormat
@@ -48,7 +48,7 @@ namespace TCPChat_Client
             {
                 Option = "list",
                 Action = ClientListAction.Execute,
-                Alias = {  },
+                Alias = { },
                 Help = "Queries the server and recieves a list of all connected users."
             });
             Commands.commandList.Add(new CommandFormat

--- a/TCPChat-Client/CommandActions.cs
+++ b/TCPChat-Client/CommandActions.cs
@@ -62,7 +62,7 @@ namespace TCPChat_Client
                 Option = "msg",
                 Action = PrivateMessageAction.Execute,
                 Alias = { },
-                Help = "Input a message to send to a specific client."
+                Help = "Input a client's ID & a message to send to a specific client."
             });
         }
     }

--- a/TCPChat-Client/CommandActions.cs
+++ b/TCPChat-Client/CommandActions.cs
@@ -1,0 +1,59 @@
+﻿using System;
+
+namespace TCPChat_Client
+{
+    class AddCommands
+    {
+        public static void Add()
+        {
+
+            CommandHandler.commandList.Add(new CommandFormat
+            {
+                Option = "help",
+                Action = HelpAction.Execute,
+            });
+            CommandHandler.commandList.Add(new CommandFormat
+            {
+                Option = "client",
+                Action = ClientDataAction.Execute,
+            });
+            CommandHandler.commandList.Add(new CommandFormat
+            {
+                Option = "exit",
+                Action = ExitAction.Execute,
+            });
+        }
+    }
+    class HelpAction
+    {
+        public static void Execute()
+        {
+            Console.WriteLine("The available commands are:");
+            for (int i = 0; i < CommandHandler.commandList.Count; i++)
+            {
+                Console.WriteLine(String.Format("/{0}", CommandHandler.commandList[i].Option));
+            }
+        }
+    }
+    class ExitAction
+    {
+        public static void Execute()
+        {
+            Environment.Exit(0);
+        }
+    }
+
+    // TODO Implement action to get certain data like color and time online from a specific user.
+    class ClientDataAction
+    {
+        public static void Execute()
+        {
+            if (String.IsNullOrWhiteSpace(CommandHandler.CommandArgument))
+            {
+                Console.WriteLine("Command requires parameters.");
+                return;
+            }
+            Console.WriteLine("{0}", CommandHandler.CommandArgument);
+        }
+    }
+}

--- a/TCPChat-Client/CommandActions.cs
+++ b/TCPChat-Client/CommandActions.cs
@@ -30,6 +30,11 @@ namespace TCPChat_Client
                 Option = "list",
                 Action = ClientListAction.Execute,
             });
+            CommandHandler.commandList.Add(new CommandFormat
+            {
+                Option = "ping",
+                Action = PingAction.Execute,
+            });
         }
     }
     class HelpAction
@@ -62,6 +67,7 @@ namespace TCPChat_Client
             {
                 MessageType = MessageTypes.DATAREQUEST,
                 DataType = CommandDataTypes.CLIENTLIST,
+                Parameters = null
             });
             MessageHandler.PrepareMessage(message, Program.staticClient, Program.staticStream, true, false);
         }
@@ -78,6 +84,21 @@ namespace TCPChat_Client
                 return;
             }
             Console.WriteLine("{0}", CommandHandler.CommandArgument);
+        }
+    }
+    class PingAction
+    {
+        public static void Execute()
+        {
+            List<DataRequestFormat> message = new List<DataRequestFormat>();
+
+            message.Add(new DataRequestFormat
+            {
+                MessageType = MessageTypes.DATAREQUEST,
+                DataType = CommandDataTypes.PING,
+                Parameters = DateTimeOffset.UnixEpoch.ToUnixTimeMilliseconds().ToString()
+            });
+            MessageHandler.PrepareMessage(message, Program.staticClient, Program.staticStream, true, false);
         }
     }
 }

--- a/TCPChat-Client/CommandActions.cs
+++ b/TCPChat-Client/CommandActions.cs
@@ -10,32 +10,32 @@ namespace TCPChat_Client
         public static void Add()
         {
 
-            CommandHandler.commandList.Add(new CommandFormat
+            Commands.commandList.Add(new CommandFormat
             {
                 Option = "help",
                 Action = HelpAction.Execute,
             });
-            CommandHandler.commandList.Add(new CommandFormat
+            Commands.commandList.Add(new CommandFormat
             {
                 Option = "client",
                 Action = ClientDataAction.Execute,
             });
-            CommandHandler.commandList.Add(new CommandFormat
+            Commands.commandList.Add(new CommandFormat
             {
                 Option = "exit",
                 Action = ExitAction.Execute,
             });
-            CommandHandler.commandList.Add(new CommandFormat
+            Commands.commandList.Add(new CommandFormat
             {
                 Option = "list",
                 Action = ClientListAction.Execute,
             });
-            CommandHandler.commandList.Add(new CommandFormat
+            Commands.commandList.Add(new CommandFormat
             {
                 Option = "ping",
                 Action = PingAction.Execute,
             });
-            CommandHandler.commandList.Add(new CommandFormat
+            Commands.commandList.Add(new CommandFormat
             {
                 Option = "clear",
                 Action = ClearAction.Execute,
@@ -47,9 +47,9 @@ namespace TCPChat_Client
         public static void Execute()
         {
             Console.WriteLine("The available commands are:");
-            for (int i = 0; i < CommandHandler.commandList.Count; i++)
+            for (int i = 0; i < Commands.commandList.Count; i++)
             {
-                Console.WriteLine(String.Format("/{0}", CommandHandler.commandList[i].Option));
+                Console.WriteLine(String.Format("/{0}", Commands.commandList[i].Option));
             }
         }
     }
@@ -83,12 +83,12 @@ namespace TCPChat_Client
     {
         public static void Execute()
         {
-            if (String.IsNullOrWhiteSpace(CommandHandler.CommandArgument))
+            if (String.IsNullOrWhiteSpace(Commands.CommandArgument))
             {
                 Console.WriteLine("Command requires parameters.");
                 return;
             }
-            Console.WriteLine("{0}", CommandHandler.CommandArgument);
+            Console.WriteLine("{0}", Commands.CommandArgument);
         }
     }
     class PingAction

--- a/TCPChat-Client/CommandActions.cs
+++ b/TCPChat-Client/CommandActions.cs
@@ -8,7 +8,7 @@ namespace TCPChat_Client
     {
         public static void Add()
         {
-
+            // TODO Improve commands with help text, alias and more information.
             Commands.commandList.Add(new CommandFormat
             {
                 Option = "help",
@@ -23,6 +23,16 @@ namespace TCPChat_Client
             {
                 Option = "exit",
                 Action = ExitAction.Execute,
+            });
+            Commands.commandList.Add(new CommandFormat
+            {
+                Option = "c",
+                Action = ChannelSwitchAction.Execute,
+            });
+            Commands.commandList.Add(new CommandFormat
+            {
+                Option = "cinfo",
+                Action = CurrentChannelAction.Execute,
             });
             Commands.commandList.Add(new CommandFormat
             {
@@ -57,6 +67,29 @@ namespace TCPChat_Client
         public static void Execute()
         {
             Environment.Exit(0);
+        }
+    }
+    class CurrentChannelAction
+    {
+        public static void Execute()
+        {
+            Console.WriteLine("Current channel is ID: {0}", ClientRecievedTypes.CurrentChannelID);
+        }
+    }
+    class ChannelSwitchAction
+    {
+        public static void Execute()
+        {
+            List<DataRequestFormat> message = new();
+
+            // TODO Documentation
+            message.Add(new DataRequestFormat
+            {
+                MessageType = MessageTypes.DATAREQUEST,
+                DataType = CommandDataTypes.CHANNELSWITCH,
+                Parameters = Commands.CommandArgument
+            });
+            MessageHandler.PrepareMessage(message, Program.staticClient, Program.staticStream, true, false);
         }
     }
     class ClientListAction

--- a/TCPChat-Client/CommandActions.cs
+++ b/TCPChat-Client/CommandActions.cs
@@ -1,7 +1,6 @@
 ﻿using CommonDefines;
 using System;
 using System.Collections.Generic;
-using System.Net.Sockets;
 
 namespace TCPChat_Client
 {

--- a/TCPChat-Client/CommandActions.cs
+++ b/TCPChat-Client/CommandActions.cs
@@ -57,6 +57,13 @@ namespace TCPChat_Client
                 Alias = { },
                 Help = "Clear your console."
             });
+            Commands.commandList.Add(new CommandFormat
+            {
+                Option = "msg",
+                Action = PrivateMessageAction.Execute,
+                Alias = { },
+                Help = "Input a message to send to a specific client."
+            });
         }
     }
     class HelpAction
@@ -92,7 +99,7 @@ namespace TCPChat_Client
             {
                 MessageType = MessageTypes.DATAREQUEST,
                 DataType = CommandDataTypes.CHANNELSWITCH,
-                Parameters = Commands.CommandArgument
+                Parameters = Commands.CommandArguments[0]
             });
             MessageHandler.PrepareMessage(message, Program.staticClient, Program.staticStream, true, false);
         }
@@ -134,6 +141,26 @@ namespace TCPChat_Client
         public static void Execute()
         {
             Console.Clear();
+        }
+    }
+    class PrivateMessageAction
+    {
+        public static void Execute()
+        {
+            List<DataRequestFormat> message = new();
+
+            if (Commands.CommandArguments[0] == null || Commands.CommandArguments[1] == null)
+            {
+                return;
+            }
+
+            message.Add(new DataRequestFormat
+            {
+                MessageType = MessageTypes.DATAREQUEST,
+                DataType = CommandDataTypes.PRIVATEMESSSAGE,
+                Parameters = String.Format("{0}, {1}", Commands.CommandArguments[0], Commands.CommandArguments[1])
+            });
+            MessageHandler.PrepareMessage(message, Program.staticClient, Program.staticStream, true, false);
         }
     }
 }

--- a/TCPChat-Client/CommandActions.cs
+++ b/TCPChat-Client/CommandActions.cs
@@ -8,7 +8,6 @@ namespace TCPChat_Client
     {
         public static void Add()
         {
-            // TODO Improve commands with help text, alias and more information.
             Commands.commandList.Add(new CommandFormat
             {
                 Option = "help",
@@ -94,7 +93,7 @@ namespace TCPChat_Client
         {
             List<DataRequestFormat> message = new();
 
-            // TODO Documentation
+            // Make a request to the server to switch to a different channel.
             message.Add(new DataRequestFormat
             {
                 MessageType = MessageTypes.DATAREQUEST,

--- a/TCPChat-Client/CommandActions.cs
+++ b/TCPChat-Client/CommandActions.cs
@@ -13,41 +13,57 @@ namespace TCPChat_Client
             {
                 Option = "help",
                 Action = HelpAction.Execute,
+                Alias = { "h" },
+                Help = "This command lists all available commands and their description."
             });
             Commands.commandList.Add(new CommandFormat
             {
                 Option = "client",
                 Action = ClientDataAction.Execute,
+                Alias = {  },
+                Help = "WIP Not in use."
             });
             Commands.commandList.Add(new CommandFormat
             {
                 Option = "exit",
                 Action = ExitAction.Execute,
+                Alias = { "q" },
+                Help = "Exit the application."
             });
             Commands.commandList.Add(new CommandFormat
             {
-                Option = "c",
+                Option = "channel",
                 Action = ChannelSwitchAction.Execute,
+                Alias = { "c" },
+                Help = "Switch your channel to ID."
             });
             Commands.commandList.Add(new CommandFormat
             {
-                Option = "cinfo",
+                Option = "channelinfo",
                 Action = CurrentChannelAction.Execute,
+                Alias = { "cinfo" },
+                Help = "Get information about your current channel."
             });
             Commands.commandList.Add(new CommandFormat
             {
                 Option = "list",
                 Action = ClientListAction.Execute,
+                Alias = {  },
+                Help = "Queries the server and recieves a list of all connected users."
             });
             Commands.commandList.Add(new CommandFormat
             {
                 Option = "ping",
                 Action = PingAction.Execute,
+                Alias = { },
+                Help = "Ping the server and see the latency between client and server."
             });
             Commands.commandList.Add(new CommandFormat
             {
                 Option = "clear",
                 Action = ClearAction.Execute,
+                Alias = { },
+                Help = "Clear your console."
             });
         }
     }
@@ -58,7 +74,19 @@ namespace TCPChat_Client
             Console.WriteLine("The available commands are:");
             for (int i = 0; i < Commands.commandList.Count; i++)
             {
+                Console.WriteLine("Command:");
                 Console.WriteLine(String.Format("/{0}", Commands.commandList[i].Option));
+                if (Commands.commandList[i].Alias.Count > 0)
+                {
+                    Console.WriteLine("Alias:");
+                }
+                for (int j = 0; j < Commands.commandList[i].Alias.Count; j++)
+                {
+                    Console.WriteLine(String.Format("/{0}", Commands.commandList[i].Alias[j]));
+                }
+                Console.WriteLine("Information:");
+                Console.WriteLine(String.Format("{0}", Commands.commandList[i].Help));
+                Console.WriteLine();
             }
         }
     }

--- a/TCPChat-Client/CommandActions.cs
+++ b/TCPChat-Client/CommandActions.cs
@@ -82,6 +82,7 @@ namespace TCPChat_Client
     }
     class CurrentChannelAction
     {
+        // TODO Show more channel information other than ID.
         public static void Execute()
         {
             Console.WriteLine("Current channel is ID: {0}", ClientRecievedTypes.CurrentChannelID);

--- a/TCPChat-Client/CommandActions.cs
+++ b/TCPChat-Client/CommandActions.cs
@@ -35,6 +35,11 @@ namespace TCPChat_Client
                 Option = "ping",
                 Action = PingAction.Execute,
             });
+            CommandHandler.commandList.Add(new CommandFormat
+            {
+                Option = "clear",
+                Action = ClearAction.Execute,
+            });
         }
     }
     class HelpAction
@@ -96,9 +101,16 @@ namespace TCPChat_Client
             {
                 MessageType = MessageTypes.DATAREQUEST,
                 DataType = CommandDataTypes.PING,
-                Parameters = DateTimeOffset.UnixEpoch.ToUnixTimeMilliseconds().ToString()
+                Parameters = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString()
             });
             MessageHandler.PrepareMessage(message, Program.staticClient, Program.staticStream, true, false);
+        }
+    }
+    class ClearAction
+    {
+        public static void Execute()
+        {
+            Console.Clear();
         }
     }
 }

--- a/TCPChat-Client/CommandActions.cs
+++ b/TCPChat-Client/CommandActions.cs
@@ -63,7 +63,7 @@ namespace TCPChat_Client
     {
         public static void Execute()
         {
-            List<DataRequestFormat> message = new List<DataRequestFormat>();
+            List<DataRequestFormat> message = new();
 
             // See the messageformat class in VariableDefines.
             // The formatting for a client's message
@@ -94,7 +94,7 @@ namespace TCPChat_Client
     {
         public static void Execute()
         {
-            List<DataRequestFormat> message = new List<DataRequestFormat>();
+            List<DataRequestFormat> message = new();
 
             message.Add(new DataRequestFormat
             {

--- a/TCPChat-Client/CommandActions.cs
+++ b/TCPChat-Client/CommandActions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿using CommonDefines;
+using System;
+using System.Collections.Generic;
+using System.Net.Sockets;
 
 namespace TCPChat_Client
 {
@@ -22,6 +25,11 @@ namespace TCPChat_Client
                 Option = "exit",
                 Action = ExitAction.Execute,
             });
+            CommandHandler.commandList.Add(new CommandFormat
+            {
+                Option = "list",
+                Action = ClientListAction.Execute,
+            });
         }
     }
     class HelpAction
@@ -40,6 +48,22 @@ namespace TCPChat_Client
         public static void Execute()
         {
             Environment.Exit(0);
+        }
+    }
+    class ClientListAction
+    {
+        public static void Execute()
+        {
+            List<DataRequestFormat> message = new List<DataRequestFormat>();
+
+            // See the messageformat class in VariableDefines.
+            // The formatting for a client's message
+            message.Add(new DataRequestFormat
+            {
+                MessageType = MessageTypes.DATAREQUEST,
+                DataType = CommandDataTypes.CLIENTLIST,
+            });
+            MessageHandler.PrepareMessage(message, Program.staticClient, Program.staticStream, true, false);
         }
     }
 

--- a/TCPChat-Client/CommandActions.cs
+++ b/TCPChat-Client/CommandActions.cs
@@ -17,13 +17,6 @@ namespace TCPChat_Client
             });
             Commands.commandList.Add(new CommandFormat
             {
-                Option = "client",
-                Action = ClientDataAction.Execute,
-                Alias = { },
-                Help = "WIP Not in use."
-            });
-            Commands.commandList.Add(new CommandFormat
-            {
                 Option = "exit",
                 Action = ExitAction.Execute,
                 Alias = { "q" },
@@ -119,20 +112,6 @@ namespace TCPChat_Client
                 Parameters = null
             });
             MessageHandler.PrepareMessage(message, Program.staticClient, Program.staticStream, true, false);
-        }
-    }
-
-    // TODO Implement action to get certain data like color and time online from a specific user.
-    class ClientDataAction
-    {
-        public static void Execute()
-        {
-            if (String.IsNullOrWhiteSpace(Commands.CommandArgument))
-            {
-                Console.WriteLine("Command requires parameters.");
-                return;
-            }
-            Console.WriteLine("{0}", Commands.CommandArgument);
         }
     }
     class PingAction

--- a/TCPChat-Client/CommandHandler.cs
+++ b/TCPChat-Client/CommandHandler.cs
@@ -1,7 +1,6 @@
 ﻿using CommonDefines;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace TCPChat_Client
 {

--- a/TCPChat-Client/CommandHandler.cs
+++ b/TCPChat-Client/CommandHandler.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TCPChat_Client
+{
+    public class CommandFormat
+    {
+        public string Option { get; set; }
+        public Action Action { get; set; }
+    }
+    public class CommandHandler
+    {
+        // Keep a list of all commands.
+        public static List<CommandFormat> commandList = new List<CommandFormat>();
+        // A variable to update when an argument is written as a command.
+        public static string CommandArgument;
+
+        public static void GetCommandType(string command)
+        {
+            string commandOption = command.Split('/', ' ')[1];
+            CommandArgument = command.Split(' ', command.Last())[1];
+
+            bool foundCommand = false;
+
+            for (int i = 0; i < commandList.Count; i++)
+            {
+                if (commandOption == commandList[i].Option)
+                {
+                    commandList[i].Action();
+                    foundCommand = true;
+                }
+            }
+            if (!foundCommand)
+            {
+                Console.WriteLine("ERROR: UNKNOWN COMMAND");
+            }
+        }
+    }
+}

--- a/TCPChat-Client/CommandHandler.cs
+++ b/TCPChat-Client/CommandHandler.cs
@@ -16,6 +16,9 @@ namespace TCPChat_Client
                 case CommandDataTypes.PING:
                     RecievedPingReply(list[0].Data);
                     break;
+                case CommandDataTypes.CHANNELSWITCH:
+                    RecievedNewChannelID(list[0].Data);
+                    break;
                 default:
                     break;
             }
@@ -29,6 +32,16 @@ namespace TCPChat_Client
         public static void RecievedPingReply(string data)
         {
             Console.WriteLine("Your latency to the server is: {0} ms", data);
+        }
+        public static void RecievedNewChannelID(string data)
+        {
+            if (int.Parse(data) == ClientRecievedTypes.CurrentChannelID)
+            {
+                Console.WriteLine("ERROR: Channel has not changed.");
+                return;
+            }
+            ClientRecievedTypes.CurrentChannelID = int.Parse(data);
+            Console.WriteLine("Channel switched to: {0}", data);
         }
     }
 }

--- a/TCPChat-Client/CommandHandler.cs
+++ b/TCPChat-Client/CommandHandler.cs
@@ -5,38 +5,8 @@ using System.Linq;
 
 namespace TCPChat_Client
 {
-    public class CommandFormat
-    {
-        public string Option { get; set; }
-        public Action Action { get; set; }
-    }
     public class CommandHandler
     {
-        // Keep a list of all commands.
-        public static List<CommandFormat> commandList = new List<CommandFormat>();
-        // A variable to update when an argument is written as a command.
-        public static string CommandArgument;
-
-        public static void GetCommandType(string command)
-        {
-            string commandOption = command.Split('/', ' ')[1];
-            CommandArgument = command.Split(' ', command.Last())[1];
-
-            bool foundCommand = false;
-
-            for (int i = 0; i < commandList.Count; i++)
-            {
-                if (commandOption == commandList[i].Option)
-                {
-                    commandList[i].Action();
-                    foundCommand = true;
-                }
-            }
-            if (!foundCommand)
-            {
-                Console.WriteLine("ERROR: UNKNOWN COMMAND");
-            }
-        }
         public static void RecievedDataReply(List<DataReplyFormat> list)
         {
             switch (list[0].DataType)

--- a/TCPChat-Client/CommandHandler.cs
+++ b/TCPChat-Client/CommandHandler.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using CommonDefines;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -35,6 +36,23 @@ namespace TCPChat_Client
             {
                 Console.WriteLine("ERROR: UNKNOWN COMMAND");
             }
+        }
+        public static void RecievedDataReply(List<DataReplyFormat> list)
+        {
+            switch (list[0].DataType)
+            {
+                case CommandDataTypes.CLIENTLIST:
+                    RecievedClientList(list[0].Data);
+                    break;
+                default:
+                    break;
+            }
+        }
+        public static void RecievedClientList(string data)
+        {
+            data = data.Replace(",", Environment.NewLine);
+            Console.WriteLine("These users are currently online:");
+            Console.WriteLine(data);
         }
     }
 }

--- a/TCPChat-Client/CommandHandler.cs
+++ b/TCPChat-Client/CommandHandler.cs
@@ -44,6 +44,9 @@ namespace TCPChat_Client
                 case CommandDataTypes.CLIENTLIST:
                     RecievedClientList(list[0].Data);
                     break;
+                case CommandDataTypes.PING:
+                    RecievedPingReply(list[0].Data);
+                    break;
                 default:
                     break;
             }
@@ -53,6 +56,10 @@ namespace TCPChat_Client
             data = data.Replace(",", Environment.NewLine);
             Console.WriteLine("These users are currently online:");
             Console.WriteLine(data);
+        }
+        public static void RecievedPingReply(string data)
+        {
+            Console.WriteLine("Your latency to the server is: {0} ms", data);
         }
     }
 }

--- a/TCPChat-Client/ConfigHandler.cs
+++ b/TCPChat-Client/ConfigHandler.cs
@@ -18,7 +18,7 @@ namespace TCPChat_Client
 
                 defaultConfig.Add(new UserConfigFormat { Username = Environment.MachineName, UserNameColor = ConsoleColor.Gray });
 
-                string serialize = Serialization.Serialize(defaultConfig);
+                string serialize = Serialization.Serialize(defaultConfig, true);
 
                 File.WriteAllText(fileDir, serialize);
 

--- a/TCPChat-Client/ConfigHandler.cs
+++ b/TCPChat-Client/ConfigHandler.cs
@@ -14,7 +14,7 @@ namespace TCPChat_Client
 
             if (!File.Exists(fileDir))
             {
-                List<UserConfigFormat> defaultConfig = new ();
+                List<UserConfigFormat> defaultConfig = new();
 
                 defaultConfig.Add(new UserConfigFormat { Username = Environment.MachineName, UserNameColor = ConsoleColor.Gray });
 

--- a/TCPChat-Client/ConfigHandler.cs
+++ b/TCPChat-Client/ConfigHandler.cs
@@ -14,7 +14,7 @@ namespace TCPChat_Client
 
             if (!File.Exists(fileDir))
             {
-                List<UserConfigFormat> defaultConfig = new List<UserConfigFormat>();
+                List<UserConfigFormat> defaultConfig = new ();
 
                 defaultConfig.Add(new UserConfigFormat { Username = Environment.MachineName, UserNameColor = ConsoleColor.Gray });
 

--- a/TCPChat-Client/ConfigHandler.cs
+++ b/TCPChat-Client/ConfigHandler.cs
@@ -16,7 +16,10 @@ namespace TCPChat_Client
             {
                 List<UserConfigFormat> defaultConfig = new();
 
-                defaultConfig.Add(new UserConfigFormat { Username = Environment.MachineName, UserNameColor = ConsoleColor.Gray });
+                defaultConfig.Add(new UserConfigFormat { 
+                    Username = Environment.MachineName, 
+                    UserNameColor = ConsoleColor.Gray 
+                });
 
                 string serialize = Serialization.Serialize(defaultConfig, true);
 

--- a/TCPChat-Client/ConfigHandler.cs
+++ b/TCPChat-Client/ConfigHandler.cs
@@ -16,9 +16,10 @@ namespace TCPChat_Client
             {
                 List<UserConfigFormat> defaultConfig = new();
 
-                defaultConfig.Add(new UserConfigFormat { 
-                    Username = Environment.MachineName, 
-                    UserNameColor = ConsoleColor.Gray 
+                defaultConfig.Add(new UserConfigFormat
+                {
+                    Username = Environment.MachineName,
+                    UserNameColor = ConsoleColor.Gray
                 });
 
                 string serialize = Serialization.Serialize(defaultConfig, true);

--- a/TCPChat-Client/Connections.cs
+++ b/TCPChat-Client/Connections.cs
@@ -15,6 +15,9 @@ namespace TCPChat_Client
                 TcpClient client = new TcpClient(serverIP, ServerPort);
                 NetworkStream stream = client.GetStream();
 
+                Program.staticClient = client;
+                Program.staticStream = stream;
+
                 Console.Title = String.Format("TCPChat - Connected to {0}", serverIP);
 
                 // Send connection message

--- a/TCPChat-Client/MessageHandler.cs
+++ b/TCPChat-Client/MessageHandler.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading;
 
 namespace TCPChat_Client

--- a/TCPChat-Client/MessageHandler.cs
+++ b/TCPChat-Client/MessageHandler.cs
@@ -18,7 +18,7 @@ namespace TCPChat_Client
             // Encrypts message and sends.
             if (Encrypt)
             {
-                EncryptSendMessage(data, client, stream);
+                EncryptSendMessage(data, stream);
             }
             // Does not encrypt, just sends.
             else
@@ -33,7 +33,7 @@ namespace TCPChat_Client
         }
 
         // Finalize message strucutre then write.
-        public static void EncryptSendMessage(byte[] message, TcpClient client, NetworkStream stream)
+        public static void EncryptSendMessage(byte[] message, NetworkStream stream)
         {
             // Encrypt Message Data
             byte[] encrypt = Encryption.AESEncrypt(message, Encryption.AESKey, Encryption.AESIV);

--- a/TCPChat-Client/MessageHandler.cs
+++ b/TCPChat-Client/MessageHandler.cs
@@ -62,8 +62,8 @@ namespace TCPChat_Client
                     // The formatting for a client's message
                     newMessage.Add(new MessageFormat
                     {
-                        messageType = MessageTypes.MESSAGE,
-                        message = messageString,
+                        MessageType = MessageTypes.MESSAGE,
+                        Message = messageString,
                         Username = UserConfigFormat.userChosenName,
                         UserNameColor = UserConfigFormat.userChosenColor
                     });
@@ -106,7 +106,7 @@ namespace TCPChat_Client
 
             List<WelcomeMessageFormat> connectList = Serialization.DeserializeWelcomeMessageFormat(text);
 
-            OutputMessage.ClientRecievedWelcomeMessageFormat(connectList);
+            ConsoleOutput.RecievedWelcomeMessageFormat(connectList);
         }
         public static void ClientRecievedEncryptedMessage(byte[] data)
         {
@@ -122,11 +122,11 @@ namespace TCPChat_Client
             {
                 case MessageTypes.MESSAGE:
                     List<MessageFormat> messageFormatList = Serialization.DeserializeMessageFormat(messageFormatted);
-                    OutputMessage.ClientRecievedMessageFormat(messageFormatList);
+                    ConsoleOutput.RecievedMessageFormat(messageFormatList);
                     break;
                 case MessageTypes.SERVER:
                     List<ServerMessageFormat> messageList = Serialization.DeserializeServerMessageFormat(messageFormatted);
-                    OutputMessage.ClientRecievedServerMessageFormat(messageList);
+                    ConsoleOutput.RecievedServerMessageFormat(messageList);
                     break;
             }
         }

--- a/TCPChat-Client/MessageHandler.cs
+++ b/TCPChat-Client/MessageHandler.cs
@@ -74,7 +74,8 @@ namespace TCPChat_Client
                             MessageType = MessageTypes.MESSAGE,
                             Message = messageString,
                             Username = UserConfigFormat.userChosenName,
-                            UserNameColor = UserConfigFormat.userChosenColor
+                            UserNameColor = UserConfigFormat.userChosenColor,
+                            ID = ClientRecievedTypes.ClientAssignedID
                         });
                         PrepareMessage(newMessage, client, stream, true, true);
                     }

--- a/TCPChat-Client/MessageHandler.cs
+++ b/TCPChat-Client/MessageHandler.cs
@@ -58,7 +58,7 @@ namespace TCPChat_Client
                     if (messageString.Substring(0, 1) == "/")
                     {
 
-                        CommandHandler.GetCommandType(messageString);
+                        Commands.GetCommandType(messageString);
                         InputMessage(client, stream);
 
                     }

--- a/TCPChat-Client/MessageHandler.cs
+++ b/TCPChat-Client/MessageHandler.cs
@@ -64,7 +64,7 @@ namespace TCPChat_Client
                     else
                     // Regular message.
                     {
-                        List<MessageFormat> newMessage = new List<MessageFormat>();
+                        List<MessageFormat> newMessage = new ();
 
                         // See the messageformat class in VariableDefines.
                         // The formatting for a client's message

--- a/TCPChat-Client/MessageHandler.cs
+++ b/TCPChat-Client/MessageHandler.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 
@@ -56,18 +55,30 @@ namespace TCPChat_Client
                 // Disallow sending empty information to stream.
                 if (!string.IsNullOrWhiteSpace(messageString))
                 {
-                    List<MessageFormat> newMessage = new List<MessageFormat>();
-
-                    // See the messageformat class in VariableDefines.
-                    // The formatting for a client's message
-                    newMessage.Add(new MessageFormat
+                    // Check if first character is / which means a command is being input.
+                    if (messageString.Substring(0, 1) == "/")
                     {
-                        MessageType = MessageTypes.MESSAGE,
-                        Message = messageString,
-                        Username = UserConfigFormat.userChosenName,
-                        UserNameColor = UserConfigFormat.userChosenColor
-                    });
-                    PrepareMessage(newMessage, client, stream, true, true);
+
+                        CommandHandler.GetCommandType(messageString);
+                        InputMessage(client, stream);
+
+                    }
+                    else
+                    // Regular message.
+                    {
+                        List<MessageFormat> newMessage = new List<MessageFormat>();
+
+                        // See the messageformat class in VariableDefines.
+                        // The formatting for a client's message
+                        newMessage.Add(new MessageFormat
+                        {
+                            MessageType = MessageTypes.MESSAGE,
+                            Message = messageString,
+                            Username = UserConfigFormat.userChosenName,
+                            UserNameColor = UserConfigFormat.userChosenColor
+                        });
+                        PrepareMessage(newMessage, client, stream, true, true);
+                    }
                 }
                 else
                 {

--- a/TCPChat-Client/MessageHandler.cs
+++ b/TCPChat-Client/MessageHandler.cs
@@ -64,7 +64,7 @@ namespace TCPChat_Client
                     else
                     // Regular message.
                     {
-                        List<MessageFormat> newMessage = new ();
+                        List<MessageFormat> newMessage = new();
 
                         // See the messageformat class in VariableDefines.
                         // The formatting for a client's message

--- a/TCPChat-Client/MessageHandler.cs
+++ b/TCPChat-Client/MessageHandler.cs
@@ -71,10 +71,7 @@ namespace TCPChat_Client
                         newMessage.Add(new MessageFormat
                         {
                             MessageType = MessageTypes.MESSAGE,
-                            Message = messageString,
-                            Username = UserConfigFormat.userChosenName,
-                            UserNameColor = UserConfigFormat.userChosenColor,
-                            ID = ClientRecievedTypes.ClientAssignedID
+                            Message = messageString
                         });
                         PrepareMessage(newMessage, client, stream, true, true);
                     }

--- a/TCPChat-Client/MessageHandler.cs
+++ b/TCPChat-Client/MessageHandler.cs
@@ -101,47 +101,12 @@ namespace TCPChat_Client
                 {
                     // Welcome can not be encrypted as that is when keys are sent.
                     case MessageTypes.WELCOME:
-                        ClientRecievedWelcomeMessage(data, bytes);
+                        ClientRecievedTypes.ClientRecievedWelcomeMessage(data, bytes);
                         break;
                     case MessageTypes.ENCRYPTED:
-                        ClientRecievedEncryptedMessage(data);
+                        ClientRecievedTypes.ClientRecievedEncryptedMessage(data);
                         break;
                 }
-            }
-        }
-        public static void ClientRecievedWelcomeMessage(byte[] data, Int32 bytes)
-        {
-            string responseData = Encoding.ASCII.GetString(data, 0, bytes);
-            string text = Common.ReturnEndOfStream(responseData);
-
-            List<WelcomeMessageFormat> connectList = Serialization.DeserializeWelcomeMessageFormat(text);
-
-            ConsoleOutput.RecievedWelcomeMessageFormat(connectList);
-        }
-        public static void ClientRecievedEncryptedMessage(byte[] data)
-        {
-            string message = Encryption.DecryptMessageData(data);
-
-
-            string messageFormatted = Common.ReturnEndOfStream(message);
-
-            // I have to return it to bytes for some reason, otherwise i get an incorrect character on byte pos 16.
-            byte[] messageBytes = Encoding.ASCII.GetBytes(messageFormatted);
-
-            switch (Common.ReturnMessageType(messageBytes))
-            {
-                case MessageTypes.MESSAGE:
-                    List<MessageFormat> messageFormatList = Serialization.DeserializeMessageFormat(messageFormatted);
-                    ConsoleOutput.RecievedMessageFormat(messageFormatList);
-                    break;
-                case MessageTypes.SERVER:
-                    List<ServerMessageFormat> serverFormatList = Serialization.DeserializeServerMessageFormat(messageFormatted);
-                    ConsoleOutput.RecievedServerMessageFormat(serverFormatList);
-                    break;
-                case MessageTypes.DATAREPLY:
-                    List<DataReplyFormat> dataFormatList = Serialization.DeserializeDataReplyFormat(messageFormatted);
-                    CommandHandler.RecievedDataReply(dataFormatList);
-                    break;
             }
         }
     }

--- a/TCPChat-Client/MessageHandler.cs
+++ b/TCPChat-Client/MessageHandler.cs
@@ -12,7 +12,7 @@ namespace TCPChat_Client
         /// Serialize the messageFormat with json to transmit.
         public static void PrepareMessage<T>(List<T> message, TcpClient client, NetworkStream stream, bool Encrypt, bool loopReadInput)
         {
-            string json = Serialization.Serialize(message);
+            string json = Serialization.Serialize(message, false);
 
             byte[] data = Serialization.AddEndCharToMessage(json);
 

--- a/TCPChat-Client/Program.cs
+++ b/TCPChat-Client/Program.cs
@@ -1,4 +1,4 @@
-﻿#define DEVMODE
+﻿//#define DEVMODE
 
 using CommonDefines;
 using System;
@@ -11,7 +11,7 @@ namespace TCPChat_Client
             ConfigHandler.WriteDefaultConfig();
             Encryption.GenerateRSAKeys();
             Encryption.GenerateAESKeys();
-
+            AddCommands.Add();
             bool quitNow = false;
             while (!quitNow)
             {

--- a/TCPChat-Client/Program.cs
+++ b/TCPChat-Client/Program.cs
@@ -2,17 +2,23 @@
 
 using CommonDefines;
 using System;
+using System.Net.Sockets;
+
 namespace TCPChat_Client
 {
     class Program
     {
+        public static TcpClient staticClient;
+        public static NetworkStream staticStream;
         static void Main(string[] args)
         {
             ConfigHandler.WriteDefaultConfig();
             Encryption.GenerateRSAKeys();
             Encryption.GenerateAESKeys();
             AddCommands.Add();
-            bool quitNow = false;
+
+
+        bool quitNow = false;
             while (!quitNow)
             {
                 Console.Title = "TCPChat - Client";

--- a/TCPChat-Client/Program.cs
+++ b/TCPChat-Client/Program.cs
@@ -21,16 +21,16 @@ namespace TCPChat_Client
                 Console.WriteLine("/config \n");
                 Console.WriteLine("/quit \n");
 #if (DEVMODE)
-                inputConnectInfo();
+                InputConnectInfo();
 #else
                 string command = Console.ReadLine();
                 switch (command)
                 {
                     case "/connect":
-                        inputConnectInfo();
+                        InputConnectInfo();
                         break;
                     case "/config":
-                        configHelp();
+                        ConfigHelp();
                         break;
                     case "/quit":
                         quitNow = true;
@@ -43,7 +43,7 @@ namespace TCPChat_Client
             }
         }
         // Prepare connection information.
-        public static void inputConnectInfo()
+        public static void InputConnectInfo()
         {
 #if (DEVMODE)
 
@@ -62,7 +62,7 @@ namespace TCPChat_Client
 #endif
 
         }
-        public static void configHelp()
+        public static void ConfigHelp()
         {
             Console.Clear();
 

--- a/TCPChat-Client/Program.cs
+++ b/TCPChat-Client/Program.cs
@@ -1,4 +1,4 @@
-﻿//#define DEVMODE
+﻿#define DEVMODE
 
 using CommonDefines;
 using System;

--- a/TCPChat-Client/Program.cs
+++ b/TCPChat-Client/Program.cs
@@ -18,7 +18,7 @@ namespace TCPChat_Client
             AddCommands.Add();
 
 
-        bool quitNow = false;
+            bool quitNow = false;
             while (!quitNow)
             {
                 Console.Title = "TCPChat - Client";

--- a/TCPChat-Client/StreamHandler.cs
+++ b/TCPChat-Client/StreamHandler.cs
@@ -1,4 +1,5 @@
 ﻿using CommonDefines;
+using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
 using System.Reflection;

--- a/TCPChat-Client/StreamHandler.cs
+++ b/TCPChat-Client/StreamHandler.cs
@@ -26,7 +26,7 @@ namespace TCPChat_Client
         }
         public static void SendConnectionMessage(TcpClient client, NetworkStream stream)
         {
-            List<ConnectionMessageFormat> message = new List<ConnectionMessageFormat>();
+            List<ConnectionMessageFormat> message = new ();
 
             // See the messageformat class in VariableDefines.
             // The formatting for a client's message

--- a/TCPChat-Client/StreamHandler.cs
+++ b/TCPChat-Client/StreamHandler.cs
@@ -26,7 +26,7 @@ namespace TCPChat_Client
         }
         public static void SendConnectionMessage(TcpClient client, NetworkStream stream)
         {
-            List<ConnectionMessageFormat> message = new ();
+            List<ConnectionMessageFormat> message = new();
 
             // See the messageformat class in VariableDefines.
             // The formatting for a client's message

--- a/TCPChat-Client/StreamHandler.cs
+++ b/TCPChat-Client/StreamHandler.cs
@@ -32,7 +32,8 @@ namespace TCPChat_Client
             // The formatting for a client's message
             message.Add(new ConnectionMessageFormat
             {
-                messageType = MessageTypes.CONNECTION,
+                MessageType = MessageTypes.CONNECTION,
+                Username = UserConfigFormat.userChosenName,
                 RSAModulus = Encryption.RSAModulus,
                 RSAExponent = Encryption.RSAExponent,
                 ClientVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString()

--- a/TCPChat-Client/StreamHandler.cs
+++ b/TCPChat-Client/StreamHandler.cs
@@ -37,6 +37,7 @@ namespace TCPChat_Client
                 RSAModulus = Encryption.RSAModulus,
                 RSAExponent = Encryption.RSAExponent,
                 ClientVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString(),
+                UserNameColor = UserConfigFormat.userChosenColor
             });
             // Do not encrypt and do not read console after.
             MessageHandler.PrepareMessage(message, client, stream, false, false);

--- a/TCPChat-Client/StreamHandler.cs
+++ b/TCPChat-Client/StreamHandler.cs
@@ -1,5 +1,4 @@
 ﻿using CommonDefines;
-using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
 using System.Reflection;

--- a/TCPChat-Client/StreamHandler.cs
+++ b/TCPChat-Client/StreamHandler.cs
@@ -36,7 +36,8 @@ namespace TCPChat_Client
                 Username = UserConfigFormat.userChosenName,
                 RSAModulus = Encryption.RSAModulus,
                 RSAExponent = Encryption.RSAExponent,
-                ClientVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString()
+                ClientVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString(),
+                ClientID = ClientRecievedTypes.ClientAssignedID
             });
             // Do not encrypt and do not read console after.
             MessageHandler.PrepareMessage(message, client, stream, false, false);

--- a/TCPChat-Client/StreamHandler.cs
+++ b/TCPChat-Client/StreamHandler.cs
@@ -38,7 +38,7 @@ namespace TCPChat_Client
                 ClientVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString()
             });
             // Do not encrypt and do not read console after.
-            MessageHandler.SerializePrepareMessage(message, client, stream, false, false);
+            MessageHandler.PrepareMessage(message, client, stream, false, false);
         }
     }
 

--- a/TCPChat-Client/StreamHandler.cs
+++ b/TCPChat-Client/StreamHandler.cs
@@ -37,7 +37,6 @@ namespace TCPChat_Client
                 RSAModulus = Encryption.RSAModulus,
                 RSAExponent = Encryption.RSAExponent,
                 ClientVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString(),
-                ClientID = ClientRecievedTypes.ClientAssignedID
             });
             // Do not encrypt and do not read console after.
             MessageHandler.PrepareMessage(message, client, stream, false, false);

--- a/TCPChat-Client/TCPChat-Client.csproj
+++ b/TCPChat-Client/TCPChat-Client.csproj
@@ -17,7 +17,7 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>..\build\</OutputPath>
-    <VersionSuffix>1.2.0.$([System.DateTime]::UtcNow.ToString(mmff))</VersionSuffix>
+    <VersionSuffix>1.3.0.$([System.DateTime]::UtcNow.ToString(MMdd))</VersionSuffix>
     <AssemblyVersion Condition=" '$(VersionSuffix)' != '' ">$(VersionSuffix)</AssemblyVersion>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionSuffix)</Version>
   </PropertyGroup>

--- a/TCPChat-Client/TCPChat-Client.csproj
+++ b/TCPChat-Client/TCPChat-Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>TCPChat_Client</RootNamespace>
     <ApplicationIcon>tcpchatlogo1.ico</ApplicationIcon>
     <RepositoryUrl></RepositoryUrl>

--- a/TCPChat-Server/Bans.cs
+++ b/TCPChat-Server/Bans.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace TCPChat_Server
 {
@@ -13,7 +11,8 @@ namespace TCPChat_Server
             if (File.Exists(bansFileLocation))
             {
                 return true;
-            } else
+            }
+            else
             {
                 return false;
             }

--- a/TCPChat-Server/Bans.cs
+++ b/TCPChat-Server/Bans.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace TCPChat_Server
+{
+    class Bans
+    {
+        public static string bansFileLocation;
+        public static bool BanDataFileExists()
+        {
+            if (File.Exists(bansFileLocation))
+            {
+                return true;
+            } else
+            {
+                return false;
+            }
+        }
+        public static void CreateBanFile()
+        {
+            bansFileLocation = String.Format(Path.Combine(Directory.GetCurrentDirectory(), "bans.dat"));
+            if (!BanDataFileExists())
+            {
+                File.Create(bansFileLocation).Dispose();
+            }
+        }
+        public static void AddNewBan(string IP)
+        {
+            if (!BanDataFileExists())
+            {
+                File.Create(bansFileLocation).Dispose();
+            }
+            File.AppendAllText(bansFileLocation, IP);
+        }
+        public static bool IsBanned(string IP)
+        {
+            if (!BanDataFileExists())
+            {
+                File.Create(bansFileLocation).Dispose();
+            }
+            foreach (string line in File.ReadLines(bansFileLocation))
+            {
+                if (line.Contains(IP))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/TCPChat-Server/ChannelHandler.cs
+++ b/TCPChat-Server/ChannelHandler.cs
@@ -1,0 +1,168 @@
+﻿using CommonDefines;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace TCPChat_Server
+{
+    public class ChannelFileFormat
+    {
+        public int ID { get; set; }
+        public string Name { get; set; }
+        // TODO Add more channel features. Such as permissions, descriptions etc.
+    }
+
+    public class ChannelHandler
+    {
+        public static string channelDataFileLocation;
+        public static List<ChannelFileFormat> serverChannels;
+        public static void CreateChannelDataFile()
+        {
+            channelDataFileLocation = String.Format(Path.Combine(Directory.GetCurrentDirectory(), "channels.json"));
+            if (!ChannelDataFileExists())
+            {
+                WriteDefaultChannels();
+            }
+            ReadChannelsFile();
+
+            if (!VerifyChannelStructure())
+            {
+                File.WriteAllText(channelDataFileLocation, "FILE FORMAT VERIFICATION FAILED.");
+            }
+        }
+        public static bool ChannelDataFileExists()
+        {
+            if (File.Exists(channelDataFileLocation))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        public static void WriteDefaultChannels()
+        {
+            List<ChannelFileFormat> defaultChannels = new();
+            // Default lobby id can be configured in serverconfig.json
+            defaultChannels.Add(new ChannelFileFormat
+            {
+                ID = 0,
+                Name = "Lobby",
+            });
+            defaultChannels.Add(new ChannelFileFormat
+            {
+                ID = 1,
+                Name = "Chat 1",
+            });
+            defaultChannels.Add(new ChannelFileFormat
+            {
+                ID = 2,
+                Name = "Chat 2",
+            });
+
+            string json = JsonSerializer.Serialize(defaultChannels, new JsonSerializerOptions { WriteIndented = true });
+
+            File.Create(channelDataFileLocation).Dispose();
+            File.WriteAllText(channelDataFileLocation, json);
+        }
+        public static void ReadChannelsFile()
+        {
+            if (ChannelDataFileExists())
+            {
+                string fileRead = File.ReadAllText(channelDataFileLocation);
+                List<ChannelFileFormat> channelsList = new ();
+                try
+                {
+                    serverChannels = JsonSerializer.Deserialize<List<ChannelFileFormat>>(fileRead);
+                }
+                catch (JsonException)
+                {
+                    // The error messages will be created in VerifyChannelStructure.
+                }
+            }
+        }
+        public static bool VerifyChannelStructure()
+        {
+            List<int> idList = new ();
+            if (!serverChannels.Any())
+            {
+                return false;
+            }
+            for (int i = 0; i < serverChannels.Count; i++)
+            {
+                // Check if there are any IDs that already exists.
+                // Could do a loop, but linq seems easier in this case.
+                if (idList.Contains(serverChannels[i].ID))
+                {
+                    return false;
+                }
+                idList.Add(serverChannels[i].ID);
+                // Anything negative is reserved. May switch to unsigned int in the future.
+                if (serverChannels[i].ID < 0)
+                {
+                    return false;
+                }
+                // Just a theoretical limit.
+                if (serverChannels[i].ID > 128)
+                {
+                    return false;
+                }
+            }
+            // Make sure at least the lobby channel exists.
+            if (!idList.Contains(ServerConfigFormat.serverChosenDefaultChannelID))
+            {
+                return false;
+            }
+            return true;
+        }
+        public static void ClientRequestsChannelSwitch(ClientInstance instance, string parameters)
+        {
+            int outNum;
+            bool parse = int.TryParse(parameters, out outNum);
+            int index = ServerMessage.FindClientKeysIndex(instance.client);
+
+            // If client has sent an invalid id.
+            if (!parse)
+            {
+                // Simply send back the users current channel id, which has not changed.
+                CommandHandler.ReplyToDataRequest(instance, ServerHandler.activeClients[index].ChannelID.ToString(), CommandDataTypes.CHANNELSWITCH);
+                return;
+            }
+
+            // Check if the client's requested new channel id actually exists.
+            bool foundID = false;
+            for (int i = 0; i < serverChannels.Count; i++)
+            {
+                if (serverChannels[i].ID == outNum)
+                {
+                    foundID = true;
+                }
+            }
+            if (!foundID)
+            {
+                // Simply send back the users current channel id, which has not changed.
+                CommandHandler.ReplyToDataRequest(instance, ServerHandler.activeClients[index].ChannelID.ToString(), CommandDataTypes.CHANNELSWITCH);
+                return;
+            }
+            // Check if client is trying to switch to the channel they are currently in.
+            if (ServerHandler.activeClients[index].ChannelID == outNum)
+            {
+                // Simply send back the users current channel id, which has not changed.
+                CommandHandler.ReplyToDataRequest(instance, ServerHandler.activeClients[index].ChannelID.ToString(), CommandDataTypes.CHANNELSWITCH);
+                return;
+            }
+
+            ServerHandler.activeClients[index].ChannelID = outNum;
+
+            CommandHandler.ReplyToDataRequest(instance, outNum.ToString(), CommandDataTypes.CHANNELSWITCH);
+
+            string message = String.Format("({0}) {1} switched channel to: {2}", ServerHandler.activeClients[index].ID, ServerHandler.activeClients[index].Username, outNum.ToString());
+            ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, message);
+        }
+    }
+}

--- a/TCPChat-Server/ChannelHandler.cs
+++ b/TCPChat-Server/ChannelHandler.cs
@@ -3,9 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
 
 namespace TCPChat_Server
 {
@@ -75,7 +73,7 @@ namespace TCPChat_Server
             if (ChannelDataFileExists())
             {
                 string fileRead = File.ReadAllText(channelDataFileLocation);
-                List<ChannelFileFormat> channelsList = new ();
+                List<ChannelFileFormat> channelsList = new();
                 try
                 {
                     serverChannels = JsonSerializer.Deserialize<List<ChannelFileFormat>>(fileRead);
@@ -88,7 +86,7 @@ namespace TCPChat_Server
         }
         public static bool VerifyChannelStructure()
         {
-            List<int> idList = new ();
+            List<int> idList = new();
             if (!serverChannels.Any())
             {
                 return false;

--- a/TCPChat-Server/ChannelHandler.cs
+++ b/TCPChat-Server/ChannelHandler.cs
@@ -73,7 +73,6 @@ namespace TCPChat_Server
             if (ChannelDataFileExists())
             {
                 string fileRead = File.ReadAllText(channelDataFileLocation);
-                List<ChannelFileFormat> channelsList = new();
                 try
                 {
                     serverChannels = JsonSerializer.Deserialize<List<ChannelFileFormat>>(fileRead);
@@ -120,8 +119,7 @@ namespace TCPChat_Server
         }
         public static void ClientRequestsChannelSwitch(ClientInstance instance, string parameters)
         {
-            int outNum;
-            bool parse = int.TryParse(parameters, out outNum);
+            bool parse = int.TryParse(parameters, out int outNum);
             int index = ServerMessage.FindClientKeysIndex(instance.client);
 
             // If client has sent an invalid id.

--- a/TCPChat-Server/CommandActions.cs
+++ b/TCPChat-Server/CommandActions.cs
@@ -8,7 +8,7 @@ namespace TCPChat_Server
     {
         public static void Add()
         {
-
+            // TODO Improve commands with help text, alias and more information.
             Commands.commandList.Add(new CommandFormat
             {
                 Option = "help",

--- a/TCPChat-Server/CommandActions.cs
+++ b/TCPChat-Server/CommandActions.cs
@@ -8,7 +8,6 @@ namespace TCPChat_Server
     {
         public static void Add()
         {
-            // TODO Improve commands with help text, alias and more information.
             Commands.commandList.Add(new CommandFormat
             {
                 Option = "help",

--- a/TCPChat-Server/CommandActions.cs
+++ b/TCPChat-Server/CommandActions.cs
@@ -95,7 +95,7 @@ namespace TCPChat_Server
                     {
                         ServerHandler.activeClients[i].TCPClient.Close();
                     }
-                    catch (ArgumentOutOfRangeException) {}
+                    catch (ArgumentOutOfRangeException) { }
                     return;
                 }
             }
@@ -118,7 +118,7 @@ namespace TCPChat_Server
                     {
                         ServerHandler.activeClients[i].TCPClient.Close();
                     }
-                    catch (ArgumentOutOfRangeException) {}
+                    catch (ArgumentOutOfRangeException) { }
                     return;
                 }
             }

--- a/TCPChat-Server/CommandActions.cs
+++ b/TCPChat-Server/CommandActions.cs
@@ -90,8 +90,12 @@ namespace TCPChat_Server
                     string message = String.Format("{0} has been banned.", ServerHandler.activeClients[i].Username);
                     ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, message);
                     Bans.AddNewBan(((IPEndPoint)ServerHandler.activeClients[i].TCPClient.Client.RemoteEndPoint).Address.ToString());
-                    // TODO Add an out of index check.
-                    ServerHandler.activeClients[i].TCPClient.Close();
+                    // Try / catch as an out of range solution. 
+                    try
+                    {
+                        ServerHandler.activeClients[i].TCPClient.Close();
+                    }
+                    catch (ArgumentOutOfRangeException) {}
                     return;
                 }
             }
@@ -109,8 +113,12 @@ namespace TCPChat_Server
                 {
                     string message = String.Format("{0} has been kicked.", ServerHandler.activeClients[i].Username);
                     ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, message);
-                    // TODO Add an out of index check.
-                    ServerHandler.activeClients[i].TCPClient.Close();
+                    // Try / catch as an out of range solution. 
+                    try
+                    {
+                        ServerHandler.activeClients[i].TCPClient.Close();
+                    }
+                    catch (ArgumentOutOfRangeException) {}
                     return;
                 }
             }

--- a/TCPChat-Server/CommandActions.cs
+++ b/TCPChat-Server/CommandActions.cs
@@ -24,10 +24,10 @@ namespace TCPChat_Server
             });
             Commands.commandList.Add(new CommandFormat
             {
-                Option = "client",
+                Option = "clientinfo",
                 Action = ClientDataAction.Execute,
-                Alias = { },
-                Help = "WIP Not in use."
+                Alias = { "c" },
+                Help = "Input a client's ID and get specific information such as username, IP etc."
             });
             Commands.commandList.Add(new CommandFormat
             {

--- a/TCPChat-Server/CommandActions.cs
+++ b/TCPChat-Server/CommandActions.cs
@@ -13,31 +13,43 @@ namespace TCPChat_Server
             {
                 Option = "help",
                 Action = HelpAction.Execute,
+                Alias = { "h" },
+                Help = "This command lists all available commands and their description."
             });
             Commands.commandList.Add(new CommandFormat
             {
                 Option = "exit",
                 Action = ExitAction.Execute,
+                Alias = { "q" },
+                Help = "Exit the application."
             });
             Commands.commandList.Add(new CommandFormat
             {
                 Option = "list",
                 Action = ClientListAction.Execute,
+                Alias = { },
+                Help = "Queries the server and recieves a list of all connected users."
             });
             Commands.commandList.Add(new CommandFormat
             {
                 Option = "clear",
                 Action = ClearAction.Execute,
+                Alias = { },
+                Help = "Clear your console."
             });
             Commands.commandList.Add(new CommandFormat
             {
                 Option = "banip",
                 Action = BanIPAction.Execute,
+                Alias = { },
+                Help = "Input a client's ID to ban their IP from the server. See bans.dat to edit bans."
             });
             Commands.commandList.Add(new CommandFormat
             {
                 Option = "kick",
                 Action = KickAction.Execute,
+                Alias = { },
+                Help = "Input a client's ID to remove them from the server temporarily."
             });
         }
     }
@@ -55,7 +67,19 @@ namespace TCPChat_Server
             Console.WriteLine("The available commands are:");
             for (int i = 0; i < Commands.commandList.Count; i++)
             {
+                Console.WriteLine("Command:");
                 Console.WriteLine(String.Format("/{0}", Commands.commandList[i].Option));
+                if (Commands.commandList[i].Alias.Count > 0)
+                {
+                    Console.WriteLine("Alias:");
+                }
+                for (int j = 0; j < Commands.commandList[i].Alias.Count; j++)
+                {
+                    Console.WriteLine(String.Format("/{0}", Commands.commandList[i].Alias[j]));
+                }
+                Console.WriteLine("Information:");
+                Console.WriteLine(String.Format("{0}", Commands.commandList[i].Help));
+                Console.WriteLine();
             }
         }
     }

--- a/TCPChat-Server/CommandActions.cs
+++ b/TCPChat-Server/CommandActions.cs
@@ -87,7 +87,7 @@ namespace TCPChat_Server
                 bool parse = int.TryParse(Commands.CommandArgument, out outNum);
                 if (parse && ServerHandler.activeClients[i].ID == outNum)
                 {
-                    string message = String.Format("{0} has been banned.", ServerHandler.activeClients[i].Username);
+                    string message = String.Format("({0}) {1} has been banned.", ServerHandler.activeClients[i].ID, ServerHandler.activeClients[i].Username);
                     ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, message);
                     Bans.AddNewBan(((IPEndPoint)ServerHandler.activeClients[i].TCPClient.Client.RemoteEndPoint).Address.ToString());
                     // Try / catch as an out of range solution. 
@@ -111,7 +111,7 @@ namespace TCPChat_Server
                 bool parse = int.TryParse(Commands.CommandArgument, out outNum);
                 if (parse && ServerHandler.activeClients[i].ID == outNum)
                 {
-                    string message = String.Format("{0} has been kicked.", ServerHandler.activeClients[i].Username);
+                    string message = String.Format("({0}) {1} has been kicked.", ServerHandler.activeClients[i].ID, ServerHandler.activeClients[i].Username);
                     ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, message);
                     // Try / catch as an out of range solution. 
                     try

--- a/TCPChat-Server/CommandActions.cs
+++ b/TCPChat-Server/CommandActions.cs
@@ -1,9 +1,6 @@
 ﻿using CommonDefines;
 using System;
-using System.Collections.Generic;
 using System.Net;
-using System.Net.Sockets;
-using System.Text;
 
 namespace TCPChat_Server
 {
@@ -116,7 +113,7 @@ namespace TCPChat_Server
                     ServerHandler.activeClients[i].TCPClient.Close();
                     return;
                 }
-            }        
+            }
         }
     }
 }

--- a/TCPChat-Server/CommandActions.cs
+++ b/TCPChat-Server/CommandActions.cs
@@ -57,6 +57,13 @@ namespace TCPChat_Server
                 Alias = { },
                 Help = "Input a client's ID to remove them from the server temporarily."
             });
+            Commands.commandList.Add(new CommandFormat
+            {
+                Option = "global",
+                Action = GlobalMessageAction.Execute,
+                Alias = { },
+                Help = "Input a message to send globally to all clients."
+            });
         }
     }
     class ExitAction
@@ -107,6 +114,13 @@ namespace TCPChat_Server
         public static void Execute()
         {
             Console.Clear();
+        }
+    }
+    class GlobalMessageAction
+    {
+        public static void Execute()
+        {
+            ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, Commands.CommandArgument);
         }
     }
     class BanIPAction

--- a/TCPChat-Server/CommandActions.cs
+++ b/TCPChat-Server/CommandActions.cs
@@ -64,30 +64,13 @@ namespace TCPChat_Server
     {
         public static void Execute()
         {
-            Console.WriteLine("The available commands are:");
-            for (int i = 0; i < Commands.commandList.Count; i++)
-            {
-                Console.WriteLine("Command:");
-                Console.WriteLine(String.Format("/{0}", Commands.commandList[i].Option));
-                if (Commands.commandList[i].Alias.Count > 0)
-                {
-                    Console.WriteLine("Alias:");
-                }
-                for (int j = 0; j < Commands.commandList[i].Alias.Count; j++)
-                {
-                    Console.WriteLine(String.Format("/{0}", Commands.commandList[i].Alias[j]));
-                }
-                Console.WriteLine("Information:");
-                Console.WriteLine(String.Format("{0}", Commands.commandList[i].Help));
-                Console.WriteLine();
-            }
+            Commands.HelpCommandCommon();
         }
     }
     class ClientListAction
     {
         public static void Execute()
         {
-
             string clients = CommandHandler.ClientListString();
             clients = clients.Replace(",", Environment.NewLine);
             Console.WriteLine("These users are currently online:");

--- a/TCPChat-Server/CommandActions.cs
+++ b/TCPChat-Server/CommandActions.cs
@@ -64,6 +64,13 @@ namespace TCPChat_Server
                 Alias = { },
                 Help = "Input a message to send globally to all clients."
             });
+            Commands.commandList.Add(new CommandFormat
+            {
+                Option = "msg",
+                Action = PrivateMessageAction.Execute,
+                Alias = { },
+                Help = "Input a message to send to a specific client."
+            });
         }
     }
     class ExitAction
@@ -86,7 +93,7 @@ namespace TCPChat_Server
         {
             for (int i = 0; i < ServerHandler.activeClients.Count; i++)
             {
-                bool parse = int.TryParse(Commands.CommandArgument, out int outNum);
+                bool parse = int.TryParse(Commands.CommandArguments[0], out int outNum);
                 if (parse && ServerHandler.activeClients[i].ID == outNum)
                 {
                     Console.WriteLine("ID: {0}", ServerHandler.activeClients[i].ID);
@@ -119,7 +126,24 @@ namespace TCPChat_Server
     {
         public static void Execute()
         {
-            ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, Commands.CommandArgument);
+            ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, Commands.CommandArguments[0]);
+        }
+    }
+    class PrivateMessageAction
+    {
+        public static void Execute()
+        {
+            for (int i = 0; i < ServerHandler.activeClients.Count; i++)
+            {
+                bool parse = int.TryParse(Commands.CommandArguments[0], out int outNum);
+                if (parse && ServerHandler.activeClients[i].ID == outNum)
+                {
+                    if (Commands.CommandArguments[1] != null)
+                    {
+                        ServerMessage.ServerClientMessage(ServerHandler.activeClients[i].TCPClient, ConsoleColor.Yellow, Commands.CommandArguments[1]);
+                    }
+                }
+            }
         }
     }
     class BanIPAction
@@ -128,7 +152,7 @@ namespace TCPChat_Server
         {
             for (int i = 0; i < ServerHandler.activeClients.Count; i++)
             {
-                bool parse = int.TryParse(Commands.CommandArgument, out int outNum);
+                bool parse = int.TryParse(Commands.CommandArguments[0], out int outNum);
                 if (parse && ServerHandler.activeClients[i].ID == outNum)
                 {
                     string message = String.Format("({0}) {1} has been banned.", ServerHandler.activeClients[i].ID, ServerHandler.activeClients[i].Username);
@@ -151,7 +175,7 @@ namespace TCPChat_Server
         {
             for (int i = 0; i < ServerHandler.activeClients.Count; i++)
             {
-                bool parse = int.TryParse(Commands.CommandArgument, out int outNum);
+                bool parse = int.TryParse(Commands.CommandArguments[0], out int outNum);
                 if (parse && ServerHandler.activeClients[i].ID == outNum)
                 {
                     string message = String.Format("({0}) {1} has been kicked.", ServerHandler.activeClients[i].ID, ServerHandler.activeClients[i].Username);

--- a/TCPChat-Server/CommandActions.cs
+++ b/TCPChat-Server/CommandActions.cs
@@ -86,8 +86,7 @@ namespace TCPChat_Server
         {
             for (int i = 0; i < ServerHandler.activeClients.Count; i++)
             {
-                int outNum;
-                bool parse = int.TryParse(Commands.CommandArgument, out outNum);
+                bool parse = int.TryParse(Commands.CommandArgument, out int outNum);
                 if (parse && ServerHandler.activeClients[i].ID == outNum)
                 {
                     Console.WriteLine("ID: {0}", ServerHandler.activeClients[i].ID);
@@ -129,8 +128,7 @@ namespace TCPChat_Server
         {
             for (int i = 0; i < ServerHandler.activeClients.Count; i++)
             {
-                int outNum;
-                bool parse = int.TryParse(Commands.CommandArgument, out outNum);
+                bool parse = int.TryParse(Commands.CommandArgument, out int outNum);
                 if (parse && ServerHandler.activeClients[i].ID == outNum)
                 {
                     string message = String.Format("({0}) {1} has been banned.", ServerHandler.activeClients[i].ID, ServerHandler.activeClients[i].Username);
@@ -153,8 +151,7 @@ namespace TCPChat_Server
         {
             for (int i = 0; i < ServerHandler.activeClients.Count; i++)
             {
-                int outNum;
-                bool parse = int.TryParse(Commands.CommandArgument, out outNum);
+                bool parse = int.TryParse(Commands.CommandArgument, out int outNum);
                 if (parse && ServerHandler.activeClients[i].ID == outNum)
                 {
                     string message = String.Format("({0}) {1} has been kicked.", ServerHandler.activeClients[i].ID, ServerHandler.activeClients[i].Username);

--- a/TCPChat-Server/CommandActions.cs
+++ b/TCPChat-Server/CommandActions.cs
@@ -24,6 +24,13 @@ namespace TCPChat_Server
             });
             Commands.commandList.Add(new CommandFormat
             {
+                Option = "client",
+                Action = ClientDataAction.Execute,
+                Alias = { },
+                Help = "WIP Not in use."
+            });
+            Commands.commandList.Add(new CommandFormat
+            {
                 Option = "list",
                 Action = ClientListAction.Execute,
                 Alias = { },
@@ -64,6 +71,25 @@ namespace TCPChat_Server
         public static void Execute()
         {
             Commands.HelpCommandCommon();
+        }
+    }
+    class ClientDataAction
+    {
+        public static void Execute()
+        {
+            for (int i = 0; i < ServerHandler.activeClients.Count; i++)
+            {
+                int outNum;
+                bool parse = int.TryParse(Commands.CommandArgument, out outNum);
+                if (parse && ServerHandler.activeClients[i].ID == outNum)
+                {
+                    Console.WriteLine("ID: {0}", ServerHandler.activeClients[i].ID);
+                    Console.WriteLine("Name: {0}", ServerHandler.activeClients[i].Username);
+                    Console.WriteLine("IP: {0}", ((IPEndPoint)ServerHandler.activeClients[i].TCPClient.Client.RemoteEndPoint).Address.ToString());
+                    Console.WriteLine("Username Color: {0}", ServerHandler.activeClients[i].UsernameColor);
+                    Console.WriteLine("Current Channel ID: {0}", ServerHandler.activeClients[i].ChannelID);
+                }
+            }
         }
     }
     class ClientListAction

--- a/TCPChat-Server/CommandActions.cs
+++ b/TCPChat-Server/CommandActions.cs
@@ -69,7 +69,7 @@ namespace TCPChat_Server
                 Option = "msg",
                 Action = PrivateMessageAction.Execute,
                 Alias = { },
-                Help = "Input a message to send to a specific client."
+                Help = "Input a client's ID & a message to send to a specific client."
             });
         }
     }

--- a/TCPChat-Server/CommandActions.cs
+++ b/TCPChat-Server/CommandActions.cs
@@ -1,0 +1,122 @@
+﻿using CommonDefines;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace TCPChat_Server
+{
+    class AddCommands
+    {
+        public static void Add()
+        {
+
+            Commands.commandList.Add(new CommandFormat
+            {
+                Option = "help",
+                Action = HelpAction.Execute,
+            });
+            Commands.commandList.Add(new CommandFormat
+            {
+                Option = "exit",
+                Action = ExitAction.Execute,
+            });
+            Commands.commandList.Add(new CommandFormat
+            {
+                Option = "list",
+                Action = ClientListAction.Execute,
+            });
+            Commands.commandList.Add(new CommandFormat
+            {
+                Option = "clear",
+                Action = ClearAction.Execute,
+            });
+            Commands.commandList.Add(new CommandFormat
+            {
+                Option = "banip",
+                Action = BanIPAction.Execute,
+            });
+            Commands.commandList.Add(new CommandFormat
+            {
+                Option = "kick",
+                Action = KickAction.Execute,
+            });
+        }
+    }
+    class ExitAction
+    {
+        public static void Execute()
+        {
+            Environment.Exit(0);
+        }
+    }
+    class HelpAction
+    {
+        public static void Execute()
+        {
+            Console.WriteLine("The available commands are:");
+            for (int i = 0; i < Commands.commandList.Count; i++)
+            {
+                Console.WriteLine(String.Format("/{0}", Commands.commandList[i].Option));
+            }
+        }
+    }
+    class ClientListAction
+    {
+        public static void Execute()
+        {
+
+            string clients = CommandHandler.ClientListString();
+            clients = clients.Replace(",", Environment.NewLine);
+            Console.WriteLine("These users are currently online:");
+            Console.WriteLine(clients);
+        }
+    }
+    class ClearAction
+    {
+        public static void Execute()
+        {
+            Console.Clear();
+        }
+    }
+    class BanIPAction
+    {
+        public static void Execute()
+        {
+            for (int i = 0; i < ServerHandler.activeClients.Count; i++)
+            {
+                int outNum;
+                bool parse = int.TryParse(Commands.CommandArgument, out outNum);
+                if (parse && ServerHandler.activeClients[i].ID == outNum)
+                {
+                    string message = String.Format("{0} has been banned.", ServerHandler.activeClients[i].Username);
+                    ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, message);
+                    Bans.AddNewBan(((IPEndPoint)ServerHandler.activeClients[i].TCPClient.Client.RemoteEndPoint).Address.ToString());
+                    // TODO Add an out of index check.
+                    ServerHandler.activeClients[i].TCPClient.Close();
+                    return;
+                }
+            }
+        }
+    }
+    class KickAction
+    {
+        public static void Execute()
+        {
+            for (int i = 0; i < ServerHandler.activeClients.Count; i++)
+            {
+                int outNum;
+                bool parse = int.TryParse(Commands.CommandArgument, out outNum);
+                if (parse && ServerHandler.activeClients[i].ID == outNum)
+                {
+                    string message = String.Format("{0} has been kicked.", ServerHandler.activeClients[i].Username);
+                    ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, message);
+                    // TODO Add an out of index check.
+                    ServerHandler.activeClients[i].TCPClient.Close();
+                    return;
+                }
+            }        
+        }
+    }
+}

--- a/TCPChat-Server/CommandHandler.cs
+++ b/TCPChat-Server/CommandHandler.cs
@@ -29,7 +29,7 @@ namespace TCPChat_Server
         }
         public static void ReplyToDataRequest(ClientInstance instance, string message, CommandDataTypes dataType)
         {
-            List<DataReplyFormat> serverMessage = new ();
+            List<DataReplyFormat> serverMessage = new();
 
             serverMessage.Add(new DataReplyFormat
             {
@@ -50,7 +50,7 @@ namespace TCPChat_Server
         }
         public static string ClientListString()
         {
-            List<string> usernames = new ();
+            List<string> usernames = new();
 
             for (int i = 0; i < ServerHandler.activeClients.Count; i++)
             {

--- a/TCPChat-Server/CommandHandler.cs
+++ b/TCPChat-Server/CommandHandler.cs
@@ -1,7 +1,6 @@
 ﻿using CommonDefines;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace TCPChat_Server
 {

--- a/TCPChat-Server/CommandHandler.cs
+++ b/TCPChat-Server/CommandHandler.cs
@@ -36,7 +36,7 @@ namespace TCPChat_Server
 
             byte[] data = Serialization.AddEndCharToMessage(json);
 
-            int index = MessageHandler.FindClientKeysIndex(instance.client);
+            int index = ServerMessage.FindClientKeysIndex(instance.client);
 
             byte[] encrypted = MessageHandler.EncryptMessage(data, ServerHandler.activeClients[index].RSAModulus, ServerHandler.activeClients[index].RSAExponent);
 

--- a/TCPChat-Server/CommandHandler.cs
+++ b/TCPChat-Server/CommandHandler.cs
@@ -14,8 +14,11 @@ namespace TCPChat_Server
             {
                 case CommandDataTypes.CLIENTLIST:
                     string clients = ClientListString();
-
                     ReplyToDataRequest(instance, clients, CommandDataTypes.CLIENTLIST);
+                    break;
+                case CommandDataTypes.PING:
+                    string replyTime = PingReply(list[0].Parameters);
+                    ReplyToDataRequest(instance, replyTime, CommandDataTypes.PING);
                     break;
                 default:
                     break;
@@ -54,7 +57,15 @@ namespace TCPChat_Server
             string finalList = String.Join(",", usernames);
 
             return finalList;
+        }
+        public static string PingReply(string pingTime)
+        {
+            long pingParse = long.Parse(pingTime);
+            long pongTime = DateTimeOffset.UnixEpoch.ToUnixTimeMilliseconds();
 
+            long timeDifference = pongTime - pingParse;
+
+            return timeDifference.ToString();
         }
     }
 }

--- a/TCPChat-Server/CommandHandler.cs
+++ b/TCPChat-Server/CommandHandler.cs
@@ -35,7 +35,7 @@ namespace TCPChat_Server
                 Data = message,
             });
 
-            string json = Serialization.Serialize(serverMessage);
+            string json = Serialization.Serialize(serverMessage, false);
 
             byte[] data = Serialization.AddEndCharToMessage(json);
 

--- a/TCPChat-Server/CommandHandler.cs
+++ b/TCPChat-Server/CommandHandler.cs
@@ -25,7 +25,7 @@ namespace TCPChat_Server
         }
         public static void ReplyToDataRequest(ClientInstance instance, string message, CommandDataTypes dataType)
         {
-            List<DataReplyFormat> serverMessage = new List<DataReplyFormat>();
+            List<DataReplyFormat> serverMessage = new ();
 
             serverMessage.Add(new DataReplyFormat
             {
@@ -46,7 +46,7 @@ namespace TCPChat_Server
         }
         public static string ClientListString()
         {
-            List<string> usernames = new List<string>();
+            List<string> usernames = new ();
 
             for (int i = 0; i < ServerHandler.activeClients.Count; i++)
             {

--- a/TCPChat-Server/CommandHandler.cs
+++ b/TCPChat-Server/CommandHandler.cs
@@ -61,7 +61,7 @@ namespace TCPChat_Server
         public static string PingReply(string pingTime)
         {
             long pingParse = long.Parse(pingTime);
-            long pongTime = DateTimeOffset.UnixEpoch.ToUnixTimeMilliseconds();
+            long pongTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
             long timeDifference = pongTime - pingParse;
 

--- a/TCPChat-Server/CommandHandler.cs
+++ b/TCPChat-Server/CommandHandler.cs
@@ -23,6 +23,10 @@ namespace TCPChat_Server
                     ClientChannelSwitch(instance, list[0].Parameters);
                     // Replies in method inside ChannelHandler
                     break;
+                case CommandDataTypes.PRIVATEMESSSAGE:
+                    ClientPrivateMessage(instance, list[0].Parameters);
+                    // Replies in method inside ChannelHandler
+                    break;
                 default:
                     break;
             }
@@ -73,6 +77,32 @@ namespace TCPChat_Server
         public static void ClientChannelSwitch(ClientInstance instance, string parameters)
         {
             ChannelHandler.ClientRequestsChannelSwitch(instance, parameters);
+        }
+        public static void ClientPrivateMessage(ClientInstance instance, string parameters)
+        {
+            string[] args = parameters.Split(',');
+
+            for (int i = 0; i < ServerHandler.activeClients.Count; i++)
+            {
+                if (args[0] == ServerHandler.activeClients[i].ID.ToString() && !String.IsNullOrEmpty(args[1]))
+                {
+                    // Get the index of the client sending the message.
+                    int index = ServerMessage.FindClientKeysIndex(instance.client);
+
+                    // Send the message to the reciever.
+                    ServerMessage.ClientPrivateMessage(
+                        ServerHandler.activeClients[i].TCPClient,
+                        ConsoleColor.Yellow,
+                        args[1],
+                        ServerHandler.activeClients[index].ID,
+                        ServerHandler.activeClients[index].Username
+                        );
+
+                    // Send a message to the sender to confirm the message has been sent.
+                    ServerMessage.ServerClientMessage(instance.client, ConsoleColor.Yellow, "Message has been sent.");
+                }
+            }
+
         }
     }
 }

--- a/TCPChat-Server/CommandHandler.cs
+++ b/TCPChat-Server/CommandHandler.cs
@@ -19,6 +19,10 @@ namespace TCPChat_Server
                     string replyTime = PingReply(list[0].Parameters);
                     ReplyToDataRequest(instance, replyTime, CommandDataTypes.PING);
                     break;
+                case CommandDataTypes.CHANNELSWITCH:
+                    ClientChannelSwitch(instance, list[0].Parameters);
+                    // Replies in method inside ChannelHandler
+                    break;
                 default:
                     break;
             }
@@ -65,6 +69,10 @@ namespace TCPChat_Server
             long timeDifference = pongTime - pingParse;
 
             return timeDifference.ToString();
+        }
+        public static void ClientChannelSwitch(ClientInstance instance, string parameters)
+        {
+            ChannelHandler.ClientRequestsChannelSwitch(instance, parameters);
         }
     }
 }

--- a/TCPChat-Server/CommandHandler.cs
+++ b/TCPChat-Server/CommandHandler.cs
@@ -1,0 +1,60 @@
+﻿using CommonDefines;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TCPChat_Server
+{
+    public class CommandHandler
+    {
+        // The server has recieved an information request from a client.
+        public static void RecievedDataRequest(ClientInstance instance, List<DataRequestFormat> list)
+        {
+            switch (list[0].DataType)
+            {
+                case CommandDataTypes.CLIENTLIST:
+                    string clients = ClientListString();
+
+                    ReplyToDataRequest(instance, clients, CommandDataTypes.CLIENTLIST);
+                    break;
+                default:
+                    break;
+            }
+        }
+        public static void ReplyToDataRequest(ClientInstance instance, string message, CommandDataTypes dataType)
+        {
+            List<DataReplyFormat> serverMessage = new List<DataReplyFormat>();
+
+            serverMessage.Add(new DataReplyFormat
+            {
+                MessageType = MessageTypes.DATAREPLY,
+                DataType = dataType,
+                Data = message,
+            });
+
+            string json = Serialization.Serialize(serverMessage);
+
+            byte[] data = Serialization.AddEndCharToMessage(json);
+
+            int index = MessageHandler.FindClientKeysIndex(instance.client);
+
+            byte[] encrypted = MessageHandler.EncryptMessage(data, ServerHandler.activeClients[index].RSAModulus, ServerHandler.activeClients[index].RSAExponent);
+
+            StreamHandler.WriteToStream(instance.stream, encrypted);
+        }
+        public static string ClientListString()
+        {
+            List<string> usernames = new List<string>();
+
+            for (int i = 0; i < ServerHandler.activeClients.Count; i++)
+            {
+                usernames.Add(ServerHandler.activeClients[i].Username);
+            }
+
+            string finalList = String.Join(",", usernames);
+
+            return finalList;
+
+        }
+    }
+}

--- a/TCPChat-Server/ConfigHandler.cs
+++ b/TCPChat-Server/ConfigHandler.cs
@@ -17,9 +17,9 @@ namespace TCPChat_Server
             {
                 List<ServerConfigFormat> defaultConfig = new List<ServerConfigFormat>();
 
-                defaultConfig.Add(new ServerConfigFormat { ServerName = "Your Server Name", ServerWelcomeMessage = "Welcome to my server!" });
+                defaultConfig.Add(new ServerConfigFormat { ServerName = "Your Server Name", ServerWelcomeMessage = "Welcome to my server!", ClientTimeBetweenMessages = 500 });
 
-                string serialize = Serialization.Serialize(defaultConfig);
+                string serialize = Serialization.Serialize(defaultConfig, true);
 
                 File.WriteAllText(fileDir, serialize);
 
@@ -35,6 +35,7 @@ namespace TCPChat_Server
 
             ServerConfigFormat.serverChosenName = userConfig[0].ServerName;
             ServerConfigFormat.serverChosenWelcomeMessage = userConfig[0].ServerWelcomeMessage;
+            ServerConfigFormat.serverChosenClientTime = userConfig[0].ClientTimeBetweenMessages;
 
         }
 

--- a/TCPChat-Server/ConfigHandler.cs
+++ b/TCPChat-Server/ConfigHandler.cs
@@ -15,7 +15,7 @@ namespace TCPChat_Server
 
             if (!File.Exists(fileDir))
             {
-                List<ServerConfigFormat> defaultConfig = new ();
+                List<ServerConfigFormat> defaultConfig = new();
 
                 defaultConfig.Add(new ServerConfigFormat { ServerName = "Your Server Name", ServerWelcomeMessage = "Welcome to my server!", ClientTimeBetweenMessages = 500, DefaultChannelID = 0 });
 

--- a/TCPChat-Server/ConfigHandler.cs
+++ b/TCPChat-Server/ConfigHandler.cs
@@ -17,7 +17,7 @@ namespace TCPChat_Server
             {
                 List<ServerConfigFormat> defaultConfig = new ();
 
-                defaultConfig.Add(new ServerConfigFormat { ServerName = "Your Server Name", ServerWelcomeMessage = "Welcome to my server!", ClientTimeBetweenMessages = 500 });
+                defaultConfig.Add(new ServerConfigFormat { ServerName = "Your Server Name", ServerWelcomeMessage = "Welcome to my server!", ClientTimeBetweenMessages = 500, DefaultChannelID = 0 });
 
                 string serialize = Serialization.Serialize(defaultConfig, true);
 
@@ -36,6 +36,7 @@ namespace TCPChat_Server
             ServerConfigFormat.serverChosenName = userConfig[0].ServerName;
             ServerConfigFormat.serverChosenWelcomeMessage = userConfig[0].ServerWelcomeMessage;
             ServerConfigFormat.serverChosenClientTime = userConfig[0].ClientTimeBetweenMessages;
+            ServerConfigFormat.serverChosenDefaultChannelID = userConfig[0].DefaultChannelID;
 
         }
 

--- a/TCPChat-Server/ConfigHandler.cs
+++ b/TCPChat-Server/ConfigHandler.cs
@@ -17,7 +17,7 @@ namespace TCPChat_Server
             {
                 List<ServerConfigFormat> defaultConfig = new List<ServerConfigFormat>();
 
-                defaultConfig.Add(new ServerConfigFormat { serverName = "Your Server Name", serverWelcomeMessage = "Welcome to my server!" });
+                defaultConfig.Add(new ServerConfigFormat { ServerName = "Your Server Name", ServerWelcomeMessage = "Welcome to my server!" });
 
                 string serialize = Serialization.Serialize(defaultConfig);
 
@@ -33,8 +33,8 @@ namespace TCPChat_Server
         {
             List<ServerConfigFormat> userConfig = DeserializeConfig(configRead);
 
-            ServerConfigFormat.serverChosenName = userConfig[0].serverName;
-            ServerConfigFormat.serverChosenWelcomeMessage = userConfig[0].serverWelcomeMessage;
+            ServerConfigFormat.serverChosenName = userConfig[0].ServerName;
+            ServerConfigFormat.serverChosenWelcomeMessage = userConfig[0].ServerWelcomeMessage;
 
         }
 

--- a/TCPChat-Server/ConfigHandler.cs
+++ b/TCPChat-Server/ConfigHandler.cs
@@ -15,7 +15,7 @@ namespace TCPChat_Server
 
             if (!File.Exists(fileDir))
             {
-                List<ServerConfigFormat> defaultConfig = new List<ServerConfigFormat>();
+                List<ServerConfigFormat> defaultConfig = new ();
 
                 defaultConfig.Add(new ServerConfigFormat { ServerName = "Your Server Name", ServerWelcomeMessage = "Welcome to my server!", ClientTimeBetweenMessages = 500 });
 

--- a/TCPChat-Server/ConfigHandler.cs
+++ b/TCPChat-Server/ConfigHandler.cs
@@ -17,7 +17,12 @@ namespace TCPChat_Server
             {
                 List<ServerConfigFormat> defaultConfig = new();
 
-                defaultConfig.Add(new ServerConfigFormat { ServerName = "Your Server Name", ServerWelcomeMessage = "Welcome to my server!", ClientTimeBetweenMessages = 500, DefaultChannelID = 0 });
+                defaultConfig.Add(new ServerConfigFormat { 
+                    ServerName = "Your Server Name", 
+                    ServerWelcomeMessage = "Welcome to my server!", 
+                    ClientTimeBetweenMessages = 500, 
+                    DefaultChannelID = 0 
+                });
 
                 string serialize = Serialization.Serialize(defaultConfig, true);
 
@@ -31,20 +36,13 @@ namespace TCPChat_Server
         }
         public static void ReadConfig(string configRead)
         {
-            List<ServerConfigFormat> userConfig = DeserializeConfig(configRead);
+            List<ServerConfigFormat> userConfig = JsonSerializer.Deserialize<List<ServerConfigFormat>>(configRead);
 
             ServerConfigFormat.serverChosenName = userConfig[0].ServerName;
             ServerConfigFormat.serverChosenWelcomeMessage = userConfig[0].ServerWelcomeMessage;
             ServerConfigFormat.serverChosenClientTime = userConfig[0].ClientTimeBetweenMessages;
             ServerConfigFormat.serverChosenDefaultChannelID = userConfig[0].DefaultChannelID;
 
-        }
-
-        public static List<ServerConfigFormat> DeserializeConfig(string config)
-        {
-            List<ServerConfigFormat> json = JsonSerializer.Deserialize<List<ServerConfigFormat>>(config);
-
-            return json;
         }
     }
 }

--- a/TCPChat-Server/ConfigHandler.cs
+++ b/TCPChat-Server/ConfigHandler.cs
@@ -22,7 +22,8 @@ namespace TCPChat_Server
                     ServerName = "Your Server Name",
                     ServerWelcomeMessage = "Welcome to my server!",
                     ClientTimeBetweenMessages = 500,
-                    DefaultChannelID = 0
+                    DefaultChannelID = 0,
+                    EnableVersionCheck = true
                 });
 
                 string serialize = Serialization.Serialize(defaultConfig, true);
@@ -43,7 +44,7 @@ namespace TCPChat_Server
             ServerConfigFormat.serverChosenWelcomeMessage = userConfig[0].ServerWelcomeMessage;
             ServerConfigFormat.serverChosenClientTime = userConfig[0].ClientTimeBetweenMessages;
             ServerConfigFormat.serverChosenDefaultChannelID = userConfig[0].DefaultChannelID;
-
+            ServerConfigFormat.serverChosenVersionCheck = userConfig[0].EnableVersionCheck;
         }
     }
 }

--- a/TCPChat-Server/ConfigHandler.cs
+++ b/TCPChat-Server/ConfigHandler.cs
@@ -17,11 +17,12 @@ namespace TCPChat_Server
             {
                 List<ServerConfigFormat> defaultConfig = new();
 
-                defaultConfig.Add(new ServerConfigFormat { 
-                    ServerName = "Your Server Name", 
-                    ServerWelcomeMessage = "Welcome to my server!", 
-                    ClientTimeBetweenMessages = 500, 
-                    DefaultChannelID = 0 
+                defaultConfig.Add(new ServerConfigFormat
+                {
+                    ServerName = "Your Server Name",
+                    ServerWelcomeMessage = "Welcome to my server!",
+                    ClientTimeBetweenMessages = 500,
+                    DefaultChannelID = 0
                 });
 
                 string serialize = Serialization.Serialize(defaultConfig, true);

--- a/TCPChat-Server/MessageHandler.cs
+++ b/TCPChat-Server/MessageHandler.cs
@@ -33,7 +33,7 @@ namespace TCPChat_Server
             string json = Serialization.Serialize(list, false);
 
             byte[] data = Serialization.AddEndCharToMessage(json);
-            
+
             for (int i = 0; i < ServerHandler.activeClients.Count; i++)
             {
                 // Same channel check.
@@ -221,7 +221,7 @@ namespace TCPChat_Server
 
             instance.clientVerified = true;
 
-            List<WelcomeMessageFormat> welcomeMessage = new ();
+            List<WelcomeMessageFormat> welcomeMessage = new();
 
             welcomeMessage.Add(new WelcomeMessageFormat
             {

--- a/TCPChat-Server/MessageHandler.cs
+++ b/TCPChat-Server/MessageHandler.cs
@@ -187,7 +187,7 @@ namespace TCPChat_Server
 
             instance.clientVerified = true;
 
-            List<WelcomeMessageFormat> welcomeMessage = new List<WelcomeMessageFormat>();
+            List<WelcomeMessageFormat> welcomeMessage = new ();
 
             welcomeMessage.Add(new WelcomeMessageFormat
             {

--- a/TCPChat-Server/MessageHandler.cs
+++ b/TCPChat-Server/MessageHandler.cs
@@ -181,7 +181,7 @@ namespace TCPChat_Server
                 return;
             }*/
 
-            string message = String.Format("{0} has connected.", list[0].Username);
+            string message = String.Format("({0}) {1} connected.", list[0].ClientID, list[0].Username);
             ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, message);
 
 

--- a/TCPChat-Server/MessageHandler.cs
+++ b/TCPChat-Server/MessageHandler.cs
@@ -128,19 +128,19 @@ namespace TCPChat_Server
                 RSAModulus = list[0].RSAModulus
             });
 
-          // Check if server and client versions are the same before continuing.
-            /*if (!VersionHandler.VersionCheck(instance, list[0].ClientVersion))
+            // Check if server and client versions are the same before continuing.
+            if (!VersionHandler.VersionCheck(instance, list[0].ClientVersion))
             {
                 // Remove the item just added to active clients.
                 // The reason it is added before is to have a list to index when sending server message to.
                 ServerHandler.activeClients.RemoveAt(ServerHandler.activeClients.Count - 1);
                 return;
-            }*/
+            }
 
             string message = String.Format("{0} has connected.", list[0].Username);
             ServerMessage(ConsoleColor.Yellow, message);
 
-            
+
             instance.clientVerified = true;
 
             List<WelcomeMessageFormat> welcomeMessage = new List<WelcomeMessageFormat>();

--- a/TCPChat-Server/MessageHandler.cs
+++ b/TCPChat-Server/MessageHandler.cs
@@ -160,7 +160,7 @@ namespace TCPChat_Server
                         messageList = Serialization.DeserializeMessageFormat(messageFormatted);
 
                         List<MessageReplyFormat> replyFormat = new();
-                        replyFormat.Add(new MessageReplyFormat 
+                        replyFormat.Add(new MessageReplyFormat
                         {
                             MessageType = MessageTypes.MESSAGEREPLY,
                             Message = messageList[0].Message,
@@ -169,14 +169,8 @@ namespace TCPChat_Server
                             UsernameColor = ServerHandler.activeClients[index].UsernameColor,
                         });
 
+                        ConsoleOutput.RecievedMessageReplyFormat(replyFormat, ServerHandler.activeClients[index].ChannelID);
 
-                        CommonDefines.ConsoleOutput.OutputMessage
-                            (
-                            messageList[0].Message, 
-                            ServerHandler.activeClients[index].Username, 
-                            ServerHandler.activeClients[index].UsernameColor, 
-                            ServerHandler.activeClients[index].ID
-                            );
 
                         // Encrypts the message and sends it to all clients.
                         RepeatToAllClientsInChannel(replyFormat, instance);

--- a/TCPChat-Server/MessageHandler.cs
+++ b/TCPChat-Server/MessageHandler.cs
@@ -87,16 +87,28 @@ namespace TCPChat_Server
         }
         public static void VerifiedRecieve(ClientInstance instance, byte[] bytes)
         {
-            string message = Encryption.DecryptMessageData(bytes);
+            // Random CryptographicException that i am not able to replicate
+            // TODO Investigate reason for exception.
+            string message = "";
+            try
+            {
+                message = Encryption.DecryptMessageData(bytes);
+
+            }
+            catch (CryptographicException)
+            {
+
+                int index = MessageHandler.FindClientKeysIndex(instance.client);
+                string serverMessage = String.Format("{0} Was kicked due to a cryptography error.", ServerHandler.activeClients[index].Username);
+                MessageHandler.ServerGlobalMessage(ConsoleColor.Yellow, serverMessage);
+                instance.client.Close();
+            }
 
             string messageFormatted = Common.ReturnEndOfStream(message);
 
-            List<MessageFormat> messageList;
-
-
-
             byte[] messageBytes = Encoding.ASCII.GetBytes(messageFormatted);
 
+            List<MessageFormat> messageList;
 
             switch (Common.ReturnMessageType(messageBytes))
             {

--- a/TCPChat-Server/MessageHandler.cs
+++ b/TCPChat-Server/MessageHandler.cs
@@ -130,7 +130,7 @@ namespace TCPChat_Server
                         if (!CheckClientID(messageList[0].ID, instance))
                         {
                             int index = ServerMessage.FindClientKeysIndex(instance.client);
-                            string serverMessage = String.Format("{0} Was kicked due to an invalid ID.", ServerHandler.activeClients[index].Username);
+                            string serverMessage = String.Format("({0}) {1} Was kicked due to an invalid ID.", ServerHandler.activeClients[index].ID, ServerHandler.activeClients[index].Username);
                             ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, serverMessage);
                             instance.client.Close();
                             return;
@@ -144,7 +144,7 @@ namespace TCPChat_Server
                     catch (JsonException)
                     {
                         int index = ServerMessage.FindClientKeysIndex(instance.client);
-                        string serverMessage = String.Format("{0} Was kicked due to an invalid message.", ServerHandler.activeClients[index].Username);
+                        string serverMessage = String.Format("({0}) {1} Was kicked due to an invalid message.", ServerHandler.activeClients[index].ID, ServerHandler.activeClients[index].Username);
                         ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, serverMessage);
                         instance.client.Close();
                     }
@@ -181,7 +181,7 @@ namespace TCPChat_Server
                 return;
             }*/
 
-            string message = String.Format("({0}) {1} connected.", list[0].ClientID, list[0].Username);
+            string message = String.Format("({0}) {1} connected.", clientID, list[0].Username);
             ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, message);
 
 
@@ -218,9 +218,9 @@ namespace TCPChat_Server
             StreamHandler.WriteToStream(instance.stream, data);
         }
         // Will find an ID to assign a new client, auto increments.
+        public static int highestID = 0;
         public static int NextAvailableClientID()
         {
-            int highestID = 0;
             for (int i = 0; i < ServerHandler.activeClients.Count; i++)
             {
                 if (ServerHandler.activeClients[i].ID >= highestID)

--- a/TCPChat-Server/MessageHandler.cs
+++ b/TCPChat-Server/MessageHandler.cs
@@ -1,7 +1,6 @@
 ﻿using CommonDefines;
 using System;
 using System.Collections.Generic;
-using System.Net.Sockets;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;

--- a/TCPChat-Server/MessageHandler.cs
+++ b/TCPChat-Server/MessageHandler.cs
@@ -207,14 +207,17 @@ namespace TCPChat_Server
                 UsernameColor = list[0].UserNameColor
             });
 
-            // Check if server and client versions are the same before continuing.
-            /*if (!VersionHandler.VersionCheck(instance, list[0].ClientVersion))
+            if (ServerConfigFormat.serverChosenVersionCheck)
             {
-                // Remove the item just added to active clients.
-                // The reason it is added before is to have a list to index when sending server message to.
-                ServerHandler.activeClients.RemoveAt(ServerHandler.activeClients.Count - 1);
-                return;
-            }*/
+                // Check if server and client versions are the same before continuing.
+                if (!VersionHandler.VersionCheck(instance, list[0].ClientVersion))
+                {
+                    // Remove the item just added to active clients.
+                    // The reason it is added before is to have a list to index when sending server message to.
+                    ServerHandler.activeClients.RemoveAt(ServerHandler.activeClients.Count - 1);
+                    return;
+                }
+            }
 
             string message = String.Format("({0}) {1} connected.", clientID, list[0].Username);
             ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, message);

--- a/TCPChat-Server/MessageHandler.cs
+++ b/TCPChat-Server/MessageHandler.cs
@@ -24,7 +24,7 @@ namespace TCPChat_Server
 
             return finalBytes;
         }
-        public static void RepeatToAllClients(List<MessageFormat> list)
+        public static void RepeatToAllClients<T>(List<T> list)
         {
             string json = Serialization.Serialize(list);
 
@@ -88,8 +88,7 @@ namespace TCPChat_Server
             string messageFormatted = MessageSerialization.ReturnEndOfStream(message);
             List<MessageFormat> messageList = Serialization.DeserializeMessageFormat(messageFormatted);
 
-            OutputMessage.ServerRecievedMessage(messageList);
-
+            ConsoleOutput.RecievedMessageFormat(messageList);
 
             // Encrypts the message and sends it to all clients.
             RepeatToAllClients(messageList);
@@ -118,17 +117,21 @@ namespace TCPChat_Server
                 return;
             }
 
+            string message = String.Format("{0} has connected.", list[0].Username);
+            ServerMessage(instance, ConsoleColor.Yellow, message);
+
+
             instance.clientVerified = true;
 
             List<WelcomeMessageFormat> welcomeMessage = new List<WelcomeMessageFormat>();
 
             welcomeMessage.Add(new WelcomeMessageFormat
             {
-                messageType = MessageTypes.WELCOME,
-                connectMessage = ServerConfigFormat.serverChosenWelcomeMessage,
-                serverName = ServerConfigFormat.serverChosenName,
-                keyExponent = Encryption.RSAExponent,
-                keyModulus = Encryption.RSAModulus,
+                MessageType = MessageTypes.WELCOME,
+                ConnectMessage = ServerConfigFormat.serverChosenWelcomeMessage,
+                ServerName = ServerConfigFormat.serverChosenName,
+                RSAExponent = Encryption.RSAExponent,
+                RSAModulus = Encryption.RSAModulus,
                 ServerVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString()
             });
 
@@ -170,14 +173,14 @@ namespace TCPChat_Server
 
             serverMessage.Add(new ServerMessageFormat
             {
-                messageType = MessageTypes.SERVER,
-                message = message,
-                color = color,
+                MessageType = MessageTypes.SERVER,
+                Message = message,
+                Color = color,
                 RSAExponent = Encryption.RSAExponent,
                 RSAModulus = Encryption.RSAModulus,
             });
-
-            Serialize(serverMessage, instance, true);
+            ConsoleOutput.RecievedServerMessageFormat(serverMessage);
+            RepeatToAllClients(serverMessage);
         }
         public static int FindClientKeysIndex(TcpClient client)
         {

--- a/TCPChat-Server/MessageHandler.cs
+++ b/TCPChat-Server/MessageHandler.cs
@@ -114,7 +114,7 @@ namespace TCPChat_Server
             });
 
           // Check if server and client versions are the same before continuing.
-            if (!VersionCheck(instance, list[0].ClientVersion))
+            if (!VersionHandler.VersionCheck(instance, list[0].ClientVersion))
             {
                 // Remove the item just added to active clients.
                 // The reason it is added before is to have a list to index when sending server message to.
@@ -156,42 +156,6 @@ namespace TCPChat_Server
             }
 
             StreamHandler.WriteToStream(instance.stream, data);
-        }
-        public static bool VersionCheck(ClientInstance instance, string clientVersion)
-        {
-            // Check if versions do not match, if not close connection.
-            if (clientVersion != Assembly.GetExecutingAssembly().GetName().Version.ToString())
-            {
-                string message = String.Format("Your version of: {0} does not match the server version of: {1}",
-                    clientVersion,
-                    Assembly.GetExecutingAssembly().GetName().Version.ToString());
-
-
-                List<ServerMessageFormat> serverMessage = new List<ServerMessageFormat>();
-
-                serverMessage.Add(new ServerMessageFormat
-                {
-                    MessageType = MessageTypes.SERVER,
-                    Message = message,
-                    Color = ConsoleColor.Yellow,
-                    RSAExponent = Encryption.RSAExponent,
-                    RSAModulus = Encryption.RSAModulus,
-                });
-
-                string json = Serialization.Serialize(serverMessage);
-
-                byte[] data = Serialization.AddEndCharToMessage(json);
-
-                int index = MessageHandler.FindClientKeysIndex(instance.client);
-
-                byte[] encrypted = EncryptMessage(data, ServerHandler.activeClients[index].RSAModulus, ServerHandler.activeClients[index].RSAExponent);
-
-                StreamHandler.WriteToStream(instance.stream, encrypted);
-
-                instance.client.Close();
-                return false;
-            }
-            return true;
         }
         public static void ServerMessage(ConsoleColor color, string message)
         {

--- a/TCPChat-Server/MessageHandler.cs
+++ b/TCPChat-Server/MessageHandler.cs
@@ -27,7 +27,7 @@ namespace TCPChat_Server
         }
         public static void RepeatToAllClients<T>(List<T> list)
         {
-            string json = Serialization.Serialize(list);
+            string json = Serialization.Serialize(list, false);
 
             byte[] data = Serialization.AddEndCharToMessage(json);
 
@@ -63,7 +63,7 @@ namespace TCPChat_Server
             while ((instance.stream.Read(bytes, 0, bytes.Length)) > 0)
             {
                 // Checks if the client has sent messages too fast.
-                if (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - lastMessage >= 500)
+                if (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - lastMessage >= ServerConfigFormat.serverChosenClientTime)
                 {
                     lastMessage = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
@@ -193,7 +193,7 @@ namespace TCPChat_Server
         }
         public static void Serialize<T>(List<T> message, ClientInstance instance, bool encrypt)
         {
-            string json = Serialization.Serialize(message);
+            string json = Serialization.Serialize(message, false);
 
             byte[] data = Serialization.AddEndCharToMessage(json);
 

--- a/TCPChat-Server/MessageHandler.cs
+++ b/TCPChat-Server/MessageHandler.cs
@@ -98,9 +98,9 @@ namespace TCPChat_Server
             catch (CryptographicException)
             {
 
-                int index = MessageHandler.FindClientKeysIndex(instance.client);
+                int index = ServerMessage.FindClientKeysIndex(instance.client);
                 string serverMessage = String.Format("{0} Was kicked due to a cryptography error.", ServerHandler.activeClients[index].Username);
-                MessageHandler.ServerGlobalMessage(ConsoleColor.Yellow, serverMessage);
+                ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, serverMessage);
                 instance.client.Close();
             }
 
@@ -126,9 +126,9 @@ namespace TCPChat_Server
                     }
                     catch (JsonException)
                     {
-                        int index = MessageHandler.FindClientKeysIndex(instance.client);
+                        int index = ServerMessage.FindClientKeysIndex(instance.client);
                         string serverMessage = String.Format("{0} Was kicked due to an invalid message.", ServerHandler.activeClients[index].Username);
-                        MessageHandler.ServerGlobalMessage(ConsoleColor.Yellow, serverMessage);
+                        ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, serverMessage);
                         instance.client.Close();
                     }
                     break;
@@ -164,7 +164,7 @@ namespace TCPChat_Server
             }
 
             string message = String.Format("{0} has connected.", list[0].Username);
-            ServerGlobalMessage(ConsoleColor.Yellow, message);
+            ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, message);
 
 
             instance.clientVerified = true;
@@ -192,60 +192,11 @@ namespace TCPChat_Server
 
             if (encrypt)
             {
-                int index = FindClientKeysIndex(instance.client);
+                int index = ServerMessage.FindClientKeysIndex(instance.client);
                 data = EncryptMessage(data, ServerHandler.activeClients[index].RSAModulus, ServerHandler.activeClients[index].RSAExponent);
             }
 
             StreamHandler.WriteToStream(instance.stream, data);
-        }
-        public static void ServerGlobalMessage(ConsoleColor color, string message)
-        {
-            List<ServerMessageFormat> serverMessage = new List<ServerMessageFormat>();
-
-            serverMessage.Add(new ServerMessageFormat
-            {
-                MessageType = MessageTypes.SERVER,
-                Message = message,
-                Color = color,
-                RSAExponent = Encryption.RSAExponent,
-                RSAModulus = Encryption.RSAModulus,
-            });
-            ConsoleOutput.RecievedServerMessageFormat(serverMessage);
-            RepeatToAllClients(serverMessage);
-        }
-        public static void ServerClientMessage(ClientInstance instance, ConsoleColor color, string message)
-        {
-            List<ServerMessageFormat> serverMessage = new List<ServerMessageFormat>();
-
-            serverMessage.Add(new ServerMessageFormat
-            {
-                MessageType = MessageTypes.SERVER,
-                Message = message,
-                Color = color,
-                RSAExponent = Encryption.RSAExponent,
-                RSAModulus = Encryption.RSAModulus,
-            });
-
-            string json = Serialization.Serialize(serverMessage);
-
-            byte[] data = Serialization.AddEndCharToMessage(json);
-
-            int index = MessageHandler.FindClientKeysIndex(instance.client);
-
-            byte[] encrypted = MessageHandler.EncryptMessage(data, ServerHandler.activeClients[index].RSAModulus, ServerHandler.activeClients[index].RSAExponent);
-
-            StreamHandler.WriteToStream(instance.stream, encrypted);
-        }
-        public static int FindClientKeysIndex(TcpClient client)
-        {
-            for (int i = 0; i < ServerHandler.activeClients.Count; i++)
-            {
-                if (ServerHandler.activeClients[i].TCPClient == client)
-                {
-                    return i;
-                }
-            }
-            return -1;
         }
     }
 }

--- a/TCPChat-Server/Program.cs
+++ b/TCPChat-Server/Program.cs
@@ -18,6 +18,7 @@ namespace TCPChat_Server
             Encryption.GenerateRSAKeys();
             Encryption.GenerateAESKeys();
             AddCommands.Add();
+            ChannelHandler.CreateChannelDataFile();
 
             bool quitNow = false;
             while (!quitNow)

--- a/TCPChat-Server/Program.cs
+++ b/TCPChat-Server/Program.cs
@@ -14,8 +14,10 @@ namespace TCPChat_Server
         {
 
             ConfigHandler.WriteDefaultConfig();
+            Bans.CreateBanFile();
             Encryption.GenerateRSAKeys();
             Encryption.GenerateAESKeys();
+            AddCommands.Add();
 
             bool quitNow = false;
             while (!quitNow)
@@ -44,6 +46,7 @@ namespace TCPChat_Server
         public static void InputServerConfig()
         {
 #if (DEVMODE)
+            ServerHandler.InputMessage();
 
             ServerHandler.StartServer("0.0.0.0", "6060");
 
@@ -54,8 +57,10 @@ namespace TCPChat_Server
             string serverPort = Console.ReadLine();
 
             // 0.0.0.0 To listen on all network interfaces
-            ServerHandler.StartServer("0.0.0.0", serverPort);
+            ServerHandler.InputMessage();
 
+            ServerHandler.StartServer("0.0.0.0", serverPort);
+            
 #endif
 
 

--- a/TCPChat-Server/Program.cs
+++ b/TCPChat-Server/Program.cs
@@ -1,4 +1,4 @@
-﻿//#define DEVMODE
+﻿#define DEVMODE
 
 using CommonDefines;
 using System;

--- a/TCPChat-Server/Program.cs
+++ b/TCPChat-Server/Program.cs
@@ -1,4 +1,4 @@
-﻿#define DEVMODE
+﻿//#define DEVMODE
 
 using CommonDefines;
 using System;

--- a/TCPChat-Server/ServerHandler.cs
+++ b/TCPChat-Server/ServerHandler.cs
@@ -92,9 +92,9 @@ namespace TCPChat_Server
                 switch (excID)
                 {
                     case 10054:
-                        int index = MessageHandler.FindClientKeysIndex(client);
+                        int index = ServerMessage.FindClientKeysIndex(client);
                         string message = String.Format("{0} disconnected.", activeClients[index].Username);
-                        MessageHandler.ServerGlobalMessage(ConsoleColor.Yellow, message);
+                        ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, message);
                         break;
                     default:
                         Console.WriteLine("Exception: {0}", e);

--- a/TCPChat-Server/ServerHandler.cs
+++ b/TCPChat-Server/ServerHandler.cs
@@ -16,7 +16,7 @@ namespace TCPChat_Server
     }
     class ServerHandler
     {
-        public static List<ClientList> activeClients = new ();
+        public static List<ClientList> activeClients = new();
 
         public static void StartServer(string serverIPString, string portServer)
         {

--- a/TCPChat-Server/ServerHandler.cs
+++ b/TCPChat-Server/ServerHandler.cs
@@ -94,9 +94,11 @@ namespace TCPChat_Server
             // Get a stream object for reading and writing
             try
             {
-                ClientInstance instance = new ClientInstance();
-                instance.client = client;
-                instance.stream = client.GetStream();
+                ClientInstance instance = new ClientInstance
+                {
+                    client = client,
+                    stream = client.GetStream()
+                };
 
                 // Check if client's IP is banned.
                 if (Bans.IsBanned(((IPEndPoint)instance.client.Client.RemoteEndPoint).Address.ToString()))

--- a/TCPChat-Server/ServerHandler.cs
+++ b/TCPChat-Server/ServerHandler.cs
@@ -122,13 +122,19 @@ namespace TCPChat_Server
             {
 
                 int excID = ExceptionData.ExceptionIdentification(e);
-
+                int index = ServerMessage.FindClientKeysIndex(client);
+                string message;
 
                 switch (excID)
                 {
+                    // Seems that 10054 now appears as of .NET 5 when a disconnect occurs.
+                    // Need to investigate if 10053 is still active.
                     case 10054:
-                        int index = ServerMessage.FindClientKeysIndex(client);
-                        string message = String.Format("({0}) {1} disconnected.", activeClients[index].ID, activeClients[index].Username);
+                        message = String.Format("({0}) {1} disconnected.", activeClients[index].ID, activeClients[index].Username);
+                        ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, message);
+                        break;
+                    case 10053:
+                        message = String.Format("({0}) {1} disconnected.", activeClients[index].ID, activeClients[index].Username);
                         ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, message);
                         break;
                     // 10004 does not need certain handling messages.

--- a/TCPChat-Server/ServerHandler.cs
+++ b/TCPChat-Server/ServerHandler.cs
@@ -69,9 +69,6 @@ namespace TCPChat_Server
                 instance.client = client;
                 instance.stream = client.GetStream();
 
-                Console.WriteLine("{0} Has Connected", ((IPEndPoint)client.Client.RemoteEndPoint).Address.ToString());
-
-
                 // Loop to receive all the data sent by the client.
                 MessageHandler.RecieveMessage(instance);
 

--- a/TCPChat-Server/ServerHandler.cs
+++ b/TCPChat-Server/ServerHandler.cs
@@ -73,7 +73,8 @@ namespace TCPChat_Server
                         Commands.GetCommandType(messageString);
                         InputMessage();
 
-                    } else
+                    }
+                    else
                     {
                         InputMessage();
                     }
@@ -130,9 +131,9 @@ namespace TCPChat_Server
                         string message = String.Format("{0} disconnected.", activeClients[index].Username);
                         ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, message);
                         break;
-                        // 10004 does not need certain handling messages.
-                        // It appears when an user is kicked or banned.
-                        // May need to be investigated further.
+                    // 10004 does not need certain handling messages.
+                    // It appears when an user is kicked or banned.
+                    // May need to be investigated further.
                     case 10004:
                         break;
                     default:

--- a/TCPChat-Server/ServerHandler.cs
+++ b/TCPChat-Server/ServerHandler.cs
@@ -48,6 +48,7 @@ namespace TCPChat_Server
             }
             catch (Exception e)
             {
+
                 Console.WriteLine("Exception: {0}", e);
                 server.Stop();
             }
@@ -77,9 +78,32 @@ namespace TCPChat_Server
                 // Will check if the client is actually sending and recieiving messages.
                 ClientHeartbeat(instance);
             }
+            // ObjectDisposedException does not contain an error code, 
+            // therefore it can not return a custom message for the moment.
+            catch (ObjectDisposedException e)
+            {
+                return;
+            }
+            // Any other exception should have an error code.
+            // https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes
             catch (Exception e)
             {
-                Console.WriteLine("Exception: {0}", e);
+
+                int excID = ExceptionData.ExceptionIdentification(e);
+
+
+                switch (excID)
+                {
+                    case 10054:
+                        int index = MessageHandler.FindClientKeysIndex(client);
+                        string message = String.Format("{0} disconnected.", activeClients[index].Username);
+                        MessageHandler.ServerMessage(ConsoleColor.Yellow, message);
+                        break;
+                    default:
+                        Console.WriteLine("Exception: {0}", e);
+                        break;
+                }
+
                 client.Close();
             }
         }

--- a/TCPChat-Server/ServerHandler.cs
+++ b/TCPChat-Server/ServerHandler.cs
@@ -16,7 +16,7 @@ namespace TCPChat_Server
     }
     class ServerHandler
     {
-        public static List<ClientList> activeClients = new List<ClientList>();
+        public static List<ClientList> activeClients = new ();
 
         public static void StartServer(string serverIPString, string portServer)
         {

--- a/TCPChat-Server/ServerHandler.cs
+++ b/TCPChat-Server/ServerHandler.cs
@@ -128,7 +128,7 @@ namespace TCPChat_Server
                 {
                     case 10054:
                         int index = ServerMessage.FindClientKeysIndex(client);
-                        string message = String.Format("(0) {1} disconnected.", activeClients[index].ID, activeClients[index].Username);
+                        string message = String.Format("({0}) {1} disconnected.", activeClients[index].ID, activeClients[index].Username);
                         ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, message);
                         break;
                     // 10004 does not need certain handling messages.

--- a/TCPChat-Server/ServerHandler.cs
+++ b/TCPChat-Server/ServerHandler.cs
@@ -128,7 +128,7 @@ namespace TCPChat_Server
                 {
                     case 10054:
                         int index = ServerMessage.FindClientKeysIndex(client);
-                        string message = String.Format("{0} disconnected.", activeClients[index].Username);
+                        string message = String.Format("(0) {1} disconnected.", activeClients[index].ID, activeClients[index].Username);
                         ServerMessage.ServerGlobalMessage(ConsoleColor.Yellow, message);
                         break;
                     // 10004 does not need certain handling messages.

--- a/TCPChat-Server/ServerHandler.cs
+++ b/TCPChat-Server/ServerHandler.cs
@@ -72,7 +72,6 @@ namespace TCPChat_Server
 
 
                 // Loop to receive all the data sent by the client.
-
                 MessageHandler.RecieveMessage(instance);
 
                 // Will check if the client is actually sending and recieiving messages.

--- a/TCPChat-Server/ServerHandler.cs
+++ b/TCPChat-Server/ServerHandler.cs
@@ -80,7 +80,7 @@ namespace TCPChat_Server
             }
             // ObjectDisposedException does not contain an error code, 
             // therefore it can not return a custom message for the moment.
-            catch (ObjectDisposedException e)
+            catch (ObjectDisposedException)
             {
                 return;
             }

--- a/TCPChat-Server/ServerHandler.cs
+++ b/TCPChat-Server/ServerHandler.cs
@@ -94,7 +94,7 @@ namespace TCPChat_Server
                     case 10054:
                         int index = MessageHandler.FindClientKeysIndex(client);
                         string message = String.Format("{0} disconnected.", activeClients[index].Username);
-                        MessageHandler.ServerMessage(ConsoleColor.Yellow, message);
+                        MessageHandler.ServerGlobalMessage(ConsoleColor.Yellow, message);
                         break;
                     default:
                         Console.WriteLine("Exception: {0}", e);

--- a/TCPChat-Server/ServerMessage.cs
+++ b/TCPChat-Server/ServerMessage.cs
@@ -1,0 +1,61 @@
+﻿using CommonDefines;
+using System;
+using System.Collections.Generic;
+using System.Net.Sockets;
+using System.Text;
+
+namespace TCPChat_Server
+{
+    public class ServerMessage
+    {
+        public static void ServerGlobalMessage(ConsoleColor color, string message)
+        {
+            List<ServerMessageFormat> serverMessage = new List<ServerMessageFormat>();
+
+            serverMessage.Add(new ServerMessageFormat
+            {
+                MessageType = MessageTypes.SERVER,
+                Message = message,
+                Color = color,
+                RSAExponent = Encryption.RSAExponent,
+                RSAModulus = Encryption.RSAModulus,
+            });
+            ConsoleOutput.RecievedServerMessageFormat(serverMessage);
+            MessageHandler.RepeatToAllClients(serverMessage);
+        }
+        public static void ServerClientMessage(ClientInstance instance, ConsoleColor color, string message)
+        {
+            List<ServerMessageFormat> serverMessage = new List<ServerMessageFormat>();
+
+            serverMessage.Add(new ServerMessageFormat
+            {
+                MessageType = MessageTypes.SERVER,
+                Message = message,
+                Color = color,
+                RSAExponent = Encryption.RSAExponent,
+                RSAModulus = Encryption.RSAModulus,
+            });
+
+            string json = Serialization.Serialize(serverMessage);
+
+            byte[] data = Serialization.AddEndCharToMessage(json);
+
+            int index = FindClientKeysIndex(instance.client);
+
+            byte[] encrypted = MessageHandler.EncryptMessage(data, ServerHandler.activeClients[index].RSAModulus, ServerHandler.activeClients[index].RSAExponent);
+
+            StreamHandler.WriteToStream(instance.stream, encrypted);
+        }
+        public static int FindClientKeysIndex(TcpClient client)
+        {
+            for (int i = 0; i < ServerHandler.activeClients.Count; i++)
+            {
+                if (ServerHandler.activeClients[i].TCPClient == client)
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+    }
+}

--- a/TCPChat-Server/ServerMessage.cs
+++ b/TCPChat-Server/ServerMessage.cs
@@ -36,7 +36,7 @@ namespace TCPChat_Server
                 RSAModulus = Encryption.RSAModulus,
             });
 
-            string json = Serialization.Serialize(serverMessage);
+            string json = Serialization.Serialize(serverMessage, false);
 
             byte[] data = Serialization.AddEndCharToMessage(json);
 

--- a/TCPChat-Server/ServerMessage.cs
+++ b/TCPChat-Server/ServerMessage.cs
@@ -9,7 +9,7 @@ namespace TCPChat_Server
     {
         public static void ServerGlobalMessage(ConsoleColor color, string message)
         {
-            List<ServerMessageFormat> serverMessage = new List<ServerMessageFormat>();
+            List<ServerMessageFormat> serverMessage = new ();
 
             serverMessage.Add(new ServerMessageFormat
             {
@@ -24,7 +24,7 @@ namespace TCPChat_Server
         }
         public static void ServerClientMessage(ClientInstance instance, ConsoleColor color, string message)
         {
-            List<ServerMessageFormat> serverMessage = new List<ServerMessageFormat>();
+            List<ServerMessageFormat> serverMessage = new ();
 
             serverMessage.Add(new ServerMessageFormat
             {

--- a/TCPChat-Server/ServerMessage.cs
+++ b/TCPChat-Server/ServerMessage.cs
@@ -9,7 +9,7 @@ namespace TCPChat_Server
     {
         public static void ServerGlobalMessage(ConsoleColor color, string message)
         {
-            List<ServerMessageFormat> serverMessage = new ();
+            List<ServerMessageFormat> serverMessage = new();
 
             serverMessage.Add(new ServerMessageFormat
             {
@@ -24,7 +24,7 @@ namespace TCPChat_Server
         }
         public static void ServerClientMessage(ClientInstance instance, ConsoleColor color, string message)
         {
-            List<ServerMessageFormat> serverMessage = new ();
+            List<ServerMessageFormat> serverMessage = new();
 
             serverMessage.Add(new ServerMessageFormat
             {

--- a/TCPChat-Server/ServerMessage.cs
+++ b/TCPChat-Server/ServerMessage.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
-using System.Text;
 
 namespace TCPChat_Server
 {

--- a/TCPChat-Server/TCPChat-Server.csproj
+++ b/TCPChat-Server/TCPChat-Server.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>TCPChat_Server</RootNamespace>
     <ApplicationIcon>tcpchatlogo1.ico</ApplicationIcon>
     <Authors>Kiwi Blank</Authors>

--- a/TCPChat-Server/TCPChat-Server.csproj
+++ b/TCPChat-Server/TCPChat-Server.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>..\build\</OutputPath>
-    <VersionSuffix>1.2.0.$([System.DateTime]::UtcNow.ToString(mmff))</VersionSuffix>
+    <VersionSuffix>1.3.0.$([System.DateTime]::UtcNow.ToString(MMdd))</VersionSuffix>
     <AssemblyVersion Condition=" '$(VersionSuffix)' != '' ">$(VersionSuffix)</AssemblyVersion>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionSuffix)</Version>
   </PropertyGroup>

--- a/TCPChat-Server/VersionHandler.cs
+++ b/TCPChat-Server/VersionHandler.cs
@@ -14,7 +14,7 @@ namespace TCPChat_Server
                     clientVersion,
                     Assembly.GetExecutingAssembly().GetName().Version.ToString());
 
-                ServerMessage.ServerClientMessage(instance, ConsoleColor.Yellow, message);
+                ServerMessage.ServerClientMessage(instance.client, ConsoleColor.Yellow, message);
 
                 instance.client.Close();
                 return false;

--- a/TCPChat-Server/VersionHandler.cs
+++ b/TCPChat-Server/VersionHandler.cs
@@ -1,0 +1,48 @@
+﻿using CommonDefines;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace TCPChat_Server
+{
+    public class VersionHandler
+    {
+        public static bool VersionCheck(ClientInstance instance, string clientVersion)
+        {
+            // Check if versions do not match, if not close connection.
+            if (clientVersion != Assembly.GetExecutingAssembly().GetName().Version.ToString())
+            {
+                string message = String.Format("Your version of: {0} does not match the server version of: {1}",
+                    clientVersion,
+                    Assembly.GetExecutingAssembly().GetName().Version.ToString());
+
+
+                List<ServerMessageFormat> serverMessage = new List<ServerMessageFormat>();
+
+                serverMessage.Add(new ServerMessageFormat
+                {
+                    MessageType = MessageTypes.SERVER,
+                    Message = message,
+                    Color = ConsoleColor.Yellow,
+                    RSAExponent = Encryption.RSAExponent,
+                    RSAModulus = Encryption.RSAModulus,
+                });
+
+                string json = Serialization.Serialize(serverMessage);
+
+                byte[] data = Serialization.AddEndCharToMessage(json);
+
+                int index = MessageHandler.FindClientKeysIndex(instance.client);
+
+                byte[] encrypted = MessageHandler.EncryptMessage(data, ServerHandler.activeClients[index].RSAModulus, ServerHandler.activeClients[index].RSAExponent);
+
+                StreamHandler.WriteToStream(instance.stream, encrypted);
+
+                instance.client.Close();
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/TCPChat-Server/VersionHandler.cs
+++ b/TCPChat-Server/VersionHandler.cs
@@ -16,7 +16,7 @@ namespace TCPChat_Server
                     clientVersion,
                     Assembly.GetExecutingAssembly().GetName().Version.ToString());
 
-                MessageHandler.ServerClientMessage(instance, ConsoleColor.Yellow, message);
+                ServerMessage.ServerClientMessage(instance, ConsoleColor.Yellow, message);
 
                 instance.client.Close();
                 return false;

--- a/TCPChat-Server/VersionHandler.cs
+++ b/TCPChat-Server/VersionHandler.cs
@@ -1,6 +1,4 @@
-﻿using CommonDefines;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Reflection;
 
 namespace TCPChat_Server

--- a/TCPChat-Server/VersionHandler.cs
+++ b/TCPChat-Server/VersionHandler.cs
@@ -16,27 +16,7 @@ namespace TCPChat_Server
                     clientVersion,
                     Assembly.GetExecutingAssembly().GetName().Version.ToString());
 
-
-                List<ServerMessageFormat> serverMessage = new List<ServerMessageFormat>();
-
-                serverMessage.Add(new ServerMessageFormat
-                {
-                    MessageType = MessageTypes.SERVER,
-                    Message = message,
-                    Color = ConsoleColor.Yellow,
-                    RSAExponent = Encryption.RSAExponent,
-                    RSAModulus = Encryption.RSAModulus,
-                });
-
-                string json = Serialization.Serialize(serverMessage);
-
-                byte[] data = Serialization.AddEndCharToMessage(json);
-
-                int index = MessageHandler.FindClientKeysIndex(instance.client);
-
-                byte[] encrypted = MessageHandler.EncryptMessage(data, ServerHandler.activeClients[index].RSAModulus, ServerHandler.activeClients[index].RSAExponent);
-
-                StreamHandler.WriteToStream(instance.stream, encrypted);
+                MessageHandler.ServerClientMessage(instance, ConsoleColor.Yellow, message);
 
                 instance.client.Close();
                 return false;

--- a/TCPChat-Server/VersionHandler.cs
+++ b/TCPChat-Server/VersionHandler.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 
 namespace TCPChat_Server
 {


### PR DESCRIPTION
TODO - Update


- Moved version check to only serverside.

- Updated build timestamp to month / day.
Fixes issue where client and server builds got different version numbers and caused a version verification error.

- Server can now send global messages.
Can be used to alert clients about kicks, connections etc.

- Disconnections and connections are now handled exceptions.
The server will globally send messages to notify clients.

- Added clientside commands.
Clients can now input commands while connected.

- Server can now respond to data requests from user commands.
Currently can only return the current client list.

- Other code improvement changes.
